### PR TITLE
Allow viewing order details from info column

### DIFF
--- a/frontend/src/CustomerDashboard.css
+++ b/frontend/src/CustomerDashboard.css
@@ -66,6 +66,23 @@
   padding: 0;
 }
 
+.info-button {
+  background-color: #f59e0b;
+  color: #ffffff;
+  border: none;
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+}
+
+.info-button:hover {
+  background-color: #d97706;
+  transform: translateY(-1px);
+}
+
 /* Nút Gia hạn */
 .extend-button {
   background-color: #10b981;     /* Xanh lá tươi */

--- a/frontend/src/CustomerDashboard.jsx
+++ b/frontend/src/CustomerDashboard.jsx
@@ -217,6 +217,7 @@ export default function CustomerDashboard() {
                   <th>Ngày mua</th>
                   <th>Ngày hết hạn</th>
                   <th>Số ngày còn lại</th>
+                  <th>Thông tin</th>
                   <th>Chức năng</th>
                 </tr>
               </thead>
@@ -252,6 +253,16 @@ export default function CustomerDashboard() {
                         <td>{expiry.toLocaleDateString('vi-VN')}</td>
                         <td>{isExpired ? 'Đã hết hạn' : `${daysLeft} ngày`}</td>
                         <td>
+                          <button
+                            type="button"
+                            className="info-button"
+                            onClick={() => setExpandedOrderId(expandedOrderId === rowId ? null : rowId)}
+                            aria-expanded={expandedOrderId === rowId}
+                          >
+                            Xem
+                          </button>
+                        </td>
+                        <td>
                           <button type="button" className="extend-button" onClick={() => handleExtendClick(o)}>
                             Gia hạn
                           </button>
@@ -260,7 +271,7 @@ export default function CustomerDashboard() {
 
                       {expandedOrderId === rowId && (
                         <tr className="order-details-row">
-                          <td colSpan={7}>
+                          <td colSpan={8}>
                             <div className="order-details">
                               <p>
                                 <strong>Email:</strong> {isExpired ? '-' : o.accountEmail || '-'}

--- a/frontend/src/PlansOverview.css
+++ b/frontend/src/PlansOverview.css
@@ -217,6 +217,59 @@
   background: #249C6A;
 }
 
+.profile-form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin: 0.5rem 0 1.5rem;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+}
+
+.profile-form h3 {
+  margin: 0;
+  color: #fff;
+  font-size: 1.1rem;
+}
+
+.profile-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-label {
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.profile-input {
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(20, 20, 20, 0.6);
+  color: #fff;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.profile-input:focus {
+  border-color: #e50914;
+  box-shadow: 0 0 0 2px rgba(229, 9, 20, 0.35);
+}
+
+.profile-hint {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
 /* 4. Responsive */
 @media (max-width: 640px) {
   /* Bố cục chuyển 1 cột, gọn khoảng cách */
@@ -312,6 +365,24 @@
     padding: 12px 16px;
     font-size: 1rem;
     border-radius: 12px;
+  }
+
+  .profile-form {
+    padding: 1.1rem;
+    gap: 1rem;
+    margin: 0.25rem 0 1rem;
+  }
+
+  .profile-form h3 {
+    font-size: 1rem;
+  }
+
+  .profile-label {
+    font-size: 0.9rem;
+  }
+
+  .profile-hint {
+    font-size: 0.75rem;
   }
 }
 .description {


### PR DESCRIPTION
## Summary
- add an explicit "Thông tin" column with a button to expand order details in the customer dashboard
- reuse the existing toggle logic so both the order code and the new info button reveal account credentials
- style the new info button to match the dashboard actions and adjust the detail row colspan

## Testing
- npm --prefix backend test *(fails: mongodb-memory-server cannot download MongoDB 7.0.14 binary due to 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d3fc05c83249a0afcfb9282ebf7