### PR TITLE
Add premium order utilities for household and profile updates

### DIFF
--- a/backend/models/Order.js
+++ b/backend/models/Order.js
@@ -51,6 +51,12 @@ const orderSchema = new Schema({
     type: Date,
   },
   accountCookies: { type: String },
+  householdNote: {
+    type: String,
+  },
+  householdUpdatedAt: {
+    type: Date,
+  },
   history: [
     {
       message: String,

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -5,7 +5,10 @@ import {
   localSavings,
   getOrders,
   extendOrder,
-  sellAccount
+  sellAccount,
+  updatePremiumProfileName,
+  updatePremiumPin,
+  requestPremiumHousehold
 } from "../controllers/orderController.js";
 import { checkCookieSession } from "../services/warrantyService.js";
 import Account50k from "../models/Account50k.js";
@@ -41,6 +44,9 @@ router.post("/sell", sellAccount);
  */
 router.get("/", authenticate, getOrders);
 router.post("/:id/extend", authenticate, extendOrder);
+router.post("/:id/household", authenticate, requestPremiumHousehold);
+router.put("/:id/profile-name", authenticate, updatePremiumProfileName);
+router.put("/:id/pin", authenticate, updatePremiumPin);
 
 /**
  * ==============================

--- a/frontend/src/CustomerDashboard.css
+++ b/frontend/src/CustomerDashboard.css
@@ -66,6 +66,23 @@
   padding: 0;
 }
 
+.info-button {
+  background-color: #f59e0b;
+  color: #ffffff;
+  border: none;
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.5rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.1s;
+}
+
+.info-button:hover {
+  background-color: #d97706;
+  transform: translateY(-1px);
+}
+
 /* Nút Gia hạn */
 .extend-button {
   background-color: #10b981;     /* Xanh lá tươi */
@@ -215,6 +232,20 @@
   border-radius: 0.5rem;
   font-size: 0.85rem;
   font-weight: 600;
+}
+
+.premium-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.premium-action-status {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #2563eb;
 }
 
 /* Nút Copy */

--- a/frontend/src/CustomerDashboard.jsx
+++ b/frontend/src/CustomerDashboard.jsx
@@ -27,11 +27,122 @@ export default function CustomerDashboard() {
   const [warrantyProcessingId, setWarrantyProcessingId] = useState(null);
   const [warrantyStep, setWarrantyStep] = useState("");
   const [dotCount, setDotCount] = useState(1);
+  const [premiumActionId, setPremiumActionId] = useState(null);
 
   // ✅ thông báo bảo hành theo từng order
   const [persistentMessages, setPersistentMessages] = useState({});
 
   const token = localStorage.getItem('token');
+
+  const normalizeId = (value) => (value ? value.toString() : '');
+
+  const applyUpdatedOrder = (updated) => {
+    if (!updated) return;
+    setOrders((prev) => {
+      if (!Array.isArray(prev)) return prev;
+      return prev.map((entry) => {
+        const entryId = normalizeId(entry._id || entry.orderCode);
+        const updatedId = normalizeId(updated._id || updated.orderCode);
+        return entryId === updatedId ? { ...entry, ...updated } : entry;
+      });
+    });
+  };
+
+  const runPremiumAction = async (order, actionFn, fallbackMessage = '') => {
+    const orderId = normalizeId(order._id || order.orderCode);
+    if (!orderId) {
+      alert('Không tìm thấy mã đơn hàng');
+      return null;
+    }
+
+    setPremiumActionId(orderId);
+    try {
+      const response = await actionFn(orderId);
+      const updatedOrder = response?.data?.order;
+      if (updatedOrder) {
+        applyUpdatedOrder(updatedOrder);
+      } else {
+        await fetchOrders();
+      }
+      const message = response?.data?.message || fallbackMessage;
+      if (message) {
+        alert(message);
+      }
+      return response;
+    } catch (err) {
+      console.error('Premium action error:', err);
+      alert(err?.response?.data?.message || 'Có lỗi xảy ra khi thực hiện chức năng');
+      return null;
+    } finally {
+      setPremiumActionId(null);
+    }
+  };
+
+  const handlePremiumAction = async (order, action) => {
+    if (!action) return;
+
+    if (action === 'household') {
+      const noteInput = window.prompt('Nhập ghi chú (có thể để trống nếu không có):', order.householdNote || '');
+      if (noteInput === null) return;
+      const trimmed = noteInput.trim();
+      await runPremiumAction(
+        order,
+        (orderId) =>
+          axios.post(
+            `http://localhost:5000/api/orders/${orderId}/household`,
+            { note: trimmed },
+            { headers: { Authorization: `Bearer ${token}` } }
+          ),
+        'Đã gửi yêu cầu cập nhật hộ gia đình'
+      );
+      return;
+    }
+
+    if (action === 'profileName') {
+      const nameInput = window.prompt('Nhập tên hồ sơ mới:', order.profileName || '');
+      if (nameInput === null) return;
+      const trimmed = nameInput.trim();
+      if (!trimmed) {
+        alert('Tên hồ sơ không được để trống');
+        return;
+      }
+      if (trimmed.length > 50) {
+        alert('Tên hồ sơ tối đa 50 ký tự');
+        return;
+      }
+      await runPremiumAction(
+        order,
+        (orderId) =>
+          axios.put(
+            `http://localhost:5000/api/orders/${orderId}/profile-name`,
+            { profileName: trimmed },
+            { headers: { Authorization: `Bearer ${token}` } }
+          ),
+        'Đã cập nhật tên hồ sơ'
+      );
+      return;
+    }
+
+    if (action === 'pin') {
+      const pinInput = window.prompt('Nhập mã PIN mới (4 chữ số):', '');
+      if (pinInput === null) return;
+      const trimmed = pinInput.trim();
+      if (!/^\d{4}$/.test(trimmed)) {
+        alert('Mã PIN phải gồm đúng 4 chữ số');
+        return;
+      }
+      await runPremiumAction(
+        order,
+        (orderId) =>
+          axios.put(
+            `http://localhost:5000/api/orders/${orderId}/pin`,
+            { pin: trimmed },
+            { headers: { Authorization: `Bearer ${token}` } }
+          ),
+        'Đã cập nhật mã PIN'
+      );
+    }
+  };
 
   // fetch orders
   const fetchOrders = async () => {
@@ -217,6 +328,7 @@ export default function CustomerDashboard() {
                   <th>Ngày mua</th>
                   <th>Ngày hết hạn</th>
                   <th>Số ngày còn lại</th>
+                  <th>Thông tin</th>
                   <th>Chức năng</th>
                 </tr>
               </thead>
@@ -233,6 +345,9 @@ export default function CustomerDashboard() {
                   const daysLeft = Math.ceil((expiry - now) / (1000 * 60 * 60 * 24));
                   const isExpired = o.status === 'EXPIRED' || daysLeft <= 0;
                   const rowId = o._id || o.orderCode;
+                  const latestHistory = Array.isArray(o.history) && o.history.length > 0
+                    ? o.history[o.history.length - 1]
+                    : null;
 
                   return (
                     <React.Fragment key={rowId}>
@@ -252,6 +367,16 @@ export default function CustomerDashboard() {
                         <td>{expiry.toLocaleDateString('vi-VN')}</td>
                         <td>{isExpired ? 'Đã hết hạn' : `${daysLeft} ngày`}</td>
                         <td>
+                          <button
+                            type="button"
+                            className="info-button"
+                            onClick={() => setExpandedOrderId(expandedOrderId === rowId ? null : rowId)}
+                            aria-expanded={expandedOrderId === rowId}
+                          >
+                            Xem
+                          </button>
+                        </td>
+                        <td>
                           <button type="button" className="extend-button" onClick={() => handleExtendClick(o)}>
                             Gia hạn
                           </button>
@@ -260,7 +385,7 @@ export default function CustomerDashboard() {
 
                       {expandedOrderId === rowId && (
                         <tr className="order-details-row">
-                          <td colSpan={7}>
+                          <td colSpan={8}>
                             <div className="order-details">
                               <p>
                                 <strong>Email:</strong> {isExpired ? '-' : o.accountEmail || '-'}
@@ -289,7 +414,34 @@ export default function CustomerDashboard() {
                                 <>
                                   <p><strong>Tên hồ sơ:</strong> {o.profileName || '-'}</p>
                                   <p><strong>Mã PIN:</strong> {o.pin || '-'}</p>
-                                  <p><strong>Ngày cập nhật:</strong> {formatHistoryEntry(o.history?.[o.history.length - 1])}</p>
+                                  <p><strong>Ngày cập nhật:</strong> {formatHistoryEntry(latestHistory)}</p>
+                                  {(o.householdNote || o.householdUpdatedAt) && (
+                                    <p>
+                                      <strong>Hộ gia đình:</strong> {o.householdNote || 'Đã cập nhật'}
+                                      {o.householdUpdatedAt && ` (${formatDateTime(o.householdUpdatedAt)})`}
+                                    </p>
+                                  )}
+                                  <div className="premium-actions">
+                                    <div className="action-select">
+                                      <select
+                                        defaultValue=""
+                                        onChange={(e) => {
+                                          const value = e.target.value;
+                                          e.target.value = '';
+                                          handlePremiumAction(o, value);
+                                        }}
+                                        disabled={premiumActionId === rowId}
+                                      >
+                                        <option value="" disabled>-- Chọn chức năng --</option>
+                                        <option value="household">Cập nhập hộ gia đình</option>
+                                        <option value="profileName">Thay đổi tên hồ sơ</option>
+                                        <option value="pin">Đổi mã PIN</option>
+                                      </select>
+                                    </div>
+                                    {premiumActionId === rowId && (
+                                      <span className="premium-action-status">Đang xử lý...</span>
+                                    )}
+                                  </div>
                                 </>
                               )}
                               {o.plan === 'Gói tiết kiệm' && !isExpired && (

--- a/frontend/src/PlansOverview.css
+++ b/frontend/src/PlansOverview.css
@@ -217,6 +217,59 @@
   background: #249C6A;
 }
 
+.profile-form {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  margin: 0.5rem 0 1.5rem;
+  padding: 1.5rem;
+  border-radius: 0.75rem;
+  background: rgba(0, 0, 0, 0.45);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+}
+
+.profile-form h3 {
+  margin: 0;
+  color: #fff;
+  font-size: 1.1rem;
+}
+
+.profile-input-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.profile-label {
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.profile-input {
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.65rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(20, 20, 20, 0.6);
+  color: #fff;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.profile-input:focus {
+  border-color: #e50914;
+  box-shadow: 0 0 0 2px rgba(229, 9, 20, 0.35);
+}
+
+.profile-hint {
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
 /* 4. Responsive */
 @media (max-width: 640px) {
   /* Bố cục chuyển 1 cột, gọn khoảng cách */
@@ -312,6 +365,24 @@
     padding: 12px 16px;
     font-size: 1rem;
     border-radius: 12px;
+  }
+
+  .profile-form {
+    padding: 1.1rem;
+    gap: 1rem;
+    margin: 0.25rem 0 1rem;
+  }
+
+  .profile-form h3 {
+    font-size: 1rem;
+  }
+
+  .profile-label {
+    font-size: 0.9rem;
+  }
+
+  .profile-hint {
+    font-size: 0.75rem;
   }
 }
 .description {


### PR DESCRIPTION
## Summary
- add helper utilities and premium update endpoints so customers can request household refreshes or change profile metadata on their own orders
- extend the order model with household tracking fields and expose the routes through the order API
- update the customer dashboard UI to surface premium actions, show household info and style the new controls

## Testing
- npm --prefix backend test *(fails: mongodb-memory-server cannot download MongoDB 7.0.14 binary due to HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d3fc05c83249a0afcfb9282ebf7