### PR TITLE
Handle rename fallback when profile cannot be deleted

### DIFF
--- a/backend/scripts/loginByCookie.js
+++ b/backend/scripts/loginByCookie.js
@@ -2209,7 +2209,21 @@ async function autoProvisionProfile(page, wantedName, pin4, { isKids = false } =
       throw e;
     }
   }
-  if (!okDel) { console.log('❌ Xoá thất bại.'); return false; }
+
+  if (!okDel) {
+    console.log('⚠️ Xoá thất bại → thử đổi tên trực tiếp thay thế…');
+    const renamed = await renameProfileById(page, res.id, wantedName, {
+      refererUrl: res.settingsUrl,
+      pin4,
+    });
+    if (renamed) {
+      console.log('✅ Đã đổi tên hồ sơ (không cần tạo mới).');
+      return true;
+    }
+    console.log('❌ Đổi tên cũng thất bại.');
+    return false;
+  }
+
   console.log('✅ Đã xoá hồ sơ:', victim);
 
   // Tạo + đặt PIN


### PR DESCRIPTION
## Summary
- add a rename fallback in the Netflix automation script so the auto flow can reuse a non-deletable profile

## Testing
- npm --prefix backend test *(fails: Jest parser error for decorators in existing test fixture)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c7762bf48324b2c8e58338d440af