### PR TITLE
Handle rename fallback when profile cannot be deleted

### DIFF
--- a/backend/scripts/loginByCookie.js
+++ b/backend/scripts/loginByCookie.js
@@ -867,24 +867,46 @@ async function clickSaveOnEdit(page) {
 
 // API: đổi tên theo settingsId (kèm optional set PIN)
 async function renameProfileById(page, settingsId, newName, { refererUrl, pin4 } = {}) {
-  const okNav = await hardGotoEditProfile(page, settingsId, refererUrl);
-  if (!okNav) { console.log('❌ Không vào được trang Edit.'); return false; }
+  const attempts = 2;
+  let confirmed = false;
+  let lastNames = null;
 
-  const typed = await typeEditProfileName(page, newName);
-  if (!typed) { console.log('❌ Không gõ được tên mới.'); return false; }
+  for (let i = 1; i <= attempts && !confirmed; i++) {
+    if (i > 1) { console.log(`🔁 Thử đổi tên lại (lần ${i}/${attempts})…`); }
 
-  const saved = await clickSaveOnEdit(page);
-  if (!saved) { console.log('⚠️ Không xác nhận được trạng thái Lưu (có thể vẫn OK).'); }
+    const okNav = await hardGotoEditProfile(page, settingsId, refererUrl);
+    if (!okNav) { console.log('❌ Không vào được trang Edit.'); return false; }
 
-  // xác nhận tên đã đổi (không bắt buộc nhưng tốt nên có)
-  try {
-    await page.goto('https://www.netflix.com/account/profiles', { waitUntil:'networkidle2', timeout:30000 }).catch(()=>{});
-    await gentleReveal(page);
-    const names = await getProfileNames(page);
-    if (!names.includes(newName)) {
+    const typed = await typeEditProfileName(page, newName);
+    if (!typed) { console.log('❌ Không gõ được tên mới.'); return false; }
+
+    const saved = await clickSaveOnEdit(page);
+    if (!saved) { console.log('⚠️ Không xác nhận được trạng thái Lưu (có thể vẫn OK).'); }
+
+    await sleep(600);
+
+    try {
+      await page.goto('https://www.netflix.com/account/profiles', { waitUntil:'networkidle2', timeout:30000 }).catch(()=>{});
+      await gentleReveal(page);
+      const names = await getProfileNames(page);
+      lastNames = names;
+      if (names.includes(newName)) {
+        confirmed = true;
+        break;
+      }
       console.log('⚠️ Danh sách chưa phản ánh tên mới:', names);
+      await sleep(800);
+    } catch {}
+  }
+
+  if (!confirmed) {
+    if (lastNames) {
+      console.log('❌ Không thấy tên mới sau khi đổi. Danh sách hiện tại:', lastNames);
+    } else {
+      console.log('❌ Không thấy tên mới sau khi đổi.');
     }
-  } catch {}
+    return false;
+  }
 
   // nếu có PIN → đặt PIN
   if (/^\d{4}$/.test(pin4 || '')) {
@@ -2209,7 +2231,21 @@ async function autoProvisionProfile(page, wantedName, pin4, { isKids = false } =
       throw e;
     }
   }
-  if (!okDel) { console.log('❌ Xoá thất bại.'); return false; }
+
+  if (!okDel) {
+    console.log('⚠️ Xoá thất bại → thử đổi tên trực tiếp thay thế…');
+    const renamed = await renameProfileById(page, res.id, wantedName, {
+      refererUrl: res.settingsUrl,
+      pin4,
+    });
+    if (renamed) {
+      console.log('✅ Đã đổi tên hồ sơ (không cần tạo mới).');
+      return true;
+    }
+    console.log('❌ Đổi tên cũng thất bại.');
+    return false;
+  }
+
   console.log('✅ Đã xoá hồ sơ:', victim);
 
   // Tạo + đặt PIN


### PR DESCRIPTION
## Summary
- add a rename fallback in the Netflix automation script so the auto flow can reuse a non-deletable profile
- ensure the rename fallback retries and confirms the new name appears before continuing

## Testing
- npm --prefix backend test *(fails: Jest parser error for decorators in existing test fixture)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c7762bf48324b2c8e58338d440af