### PR TITLE
Link customer rename and PIN requests to Netflix automation

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -5,7 +5,11 @@ import Order from "../models/Order.js";
 import Account50k from "../models/Account50k.js";
 import NetflixAccount from "../models/NetflixAccount.js";
 import Customer from "../models/Customer.js";
-import { triggerNetflixAutomation } from "../services/netflixAutomation.js";
+import {
+  triggerNetflixAutomation,
+  triggerNetflixPinUpdate,
+  triggerNetflixProfileRename,
+} from "../services/netflixAutomation.js";
 
 /** Determine whether the current MongoDB topology supports transactions. */
 function supportsTransactions() {
@@ -534,6 +538,14 @@ export async function updatePremiumProfileName(req, res) {
       });
     }
 
+    const previousName = profile.name || order.profileName || "";
+    const automationPin = (() => {
+      const fromProfile = typeof profile.pin === "string" ? profile.pin.trim() : "";
+      if (/^\d{4}$/.test(fromProfile)) return fromProfile;
+      const fromOrder = typeof order.pin === "string" ? order.pin.trim() : "";
+      return fromOrder;
+    })();
+
     profile.name = normalizedName;
     await account.save();
 
@@ -548,6 +560,23 @@ export async function updatePremiumProfileName(req, res) {
 
     await order.save();
     const updatedOrder = await reloadOrderLean(order._id);
+
+    if (previousName && previousName !== normalizedName) {
+      triggerNetflixProfileRename({
+        email: account.email,
+        password: account.password,
+        currentProfileName: previousName,
+        newProfileName: normalizedName,
+        pin: automationPin,
+      });
+    } else if (!previousName && /^\d{4}$/.test(automationPin)) {
+      triggerNetflixAutomation({
+        email: account.email,
+        password: account.password,
+        profileName: normalizedName,
+        pin: automationPin,
+      });
+    }
 
     return res.json({
       success: true,
@@ -614,6 +643,20 @@ export async function updatePremiumPin(req, res) {
 
     await order.save();
     const updatedOrder = await reloadOrderLean(order._id);
+
+    const profileNameForPin = (() => {
+      const fromProfile = typeof profile.name === "string" ? profile.name.trim() : "";
+      if (fromProfile) return fromProfile;
+      const fromOrder = typeof order.profileName === "string" ? order.profileName.trim() : "";
+      return fromOrder;
+    })();
+
+    triggerNetflixPinUpdate({
+      email: account.email,
+      password: account.password,
+      profileName: profileNameForPin,
+      pin: normalizedPin,
+    });
 
     return res.json({
       success: true,

--- a/backend/scripts/loginByCookie.js
+++ b/backend/scripts/loginByCookie.js
@@ -867,24 +867,46 @@ async function clickSaveOnEdit(page) {
 
 // API: đổi tên theo settingsId (kèm optional set PIN)
 async function renameProfileById(page, settingsId, newName, { refererUrl, pin4 } = {}) {
-  const okNav = await hardGotoEditProfile(page, settingsId, refererUrl);
-  if (!okNav) { console.log('❌ Không vào được trang Edit.'); return false; }
+  const attempts = 2;
+  let confirmed = false;
+  let lastNames = null;
 
-  const typed = await typeEditProfileName(page, newName);
-  if (!typed) { console.log('❌ Không gõ được tên mới.'); return false; }
+  for (let i = 1; i <= attempts && !confirmed; i++) {
+    if (i > 1) { console.log(`🔁 Thử đổi tên lại (lần ${i}/${attempts})…`); }
 
-  const saved = await clickSaveOnEdit(page);
-  if (!saved) { console.log('⚠️ Không xác nhận được trạng thái Lưu (có thể vẫn OK).'); }
+    const okNav = await hardGotoEditProfile(page, settingsId, refererUrl);
+    if (!okNav) { console.log('❌ Không vào được trang Edit.'); return false; }
 
-  // xác nhận tên đã đổi (không bắt buộc nhưng tốt nên có)
-  try {
-    await page.goto('https://www.netflix.com/account/profiles', { waitUntil:'networkidle2', timeout:30000 }).catch(()=>{});
-    await gentleReveal(page);
-    const names = await getProfileNames(page);
-    if (!names.includes(newName)) {
+    const typed = await typeEditProfileName(page, newName);
+    if (!typed) { console.log('❌ Không gõ được tên mới.'); return false; }
+
+    const saved = await clickSaveOnEdit(page);
+    if (!saved) { console.log('⚠️ Không xác nhận được trạng thái Lưu (có thể vẫn OK).'); }
+
+    await sleep(600);
+
+    try {
+      await page.goto('https://www.netflix.com/account/profiles', { waitUntil:'networkidle2', timeout:30000 }).catch(()=>{});
+      await gentleReveal(page);
+      const names = await getProfileNames(page);
+      lastNames = names;
+      if (names.includes(newName)) {
+        confirmed = true;
+        break;
+      }
       console.log('⚠️ Danh sách chưa phản ánh tên mới:', names);
+      await sleep(800);
+    } catch {}
+  }
+
+  if (!confirmed) {
+    if (lastNames) {
+      console.log('❌ Không thấy tên mới sau khi đổi. Danh sách hiện tại:', lastNames);
+    } else {
+      console.log('❌ Không thấy tên mới sau khi đổi.');
     }
-  } catch {}
+    return false;
+  }
 
   // nếu có PIN → đặt PIN
   if (/^\d{4}$/.test(pin4 || '')) {
@@ -2209,7 +2231,21 @@ async function autoProvisionProfile(page, wantedName, pin4, { isKids = false } =
       throw e;
     }
   }
-  if (!okDel) { console.log('❌ Xoá thất bại.'); return false; }
+
+  if (!okDel) {
+    console.log('⚠️ Xoá thất bại → thử đổi tên trực tiếp thay thế…');
+    const renamed = await renameProfileById(page, res.id, wantedName, {
+      refererUrl: res.settingsUrl,
+      pin4,
+    });
+    if (renamed) {
+      console.log('✅ Đã đổi tên hồ sơ (không cần tạo mới).');
+      return true;
+    }
+    console.log('❌ Đổi tên cũng thất bại.');
+    return false;
+  }
+
   console.log('✅ Đã xoá hồ sơ:', victim);
 
   // Tạo + đặt PIN

--- a/backend/services/netflixAutomation.js
+++ b/backend/services/netflixAutomation.js
@@ -20,6 +20,79 @@ function sanitizeSegment(input) {
     .slice(0, 60) || "netflix";
 }
 
+function prepareAutomationContext(email) {
+  const safeSegment = sanitizeSegment(email);
+  const cacheRoot = path.resolve(backendRoot, ".netflix-cache", safeSegment);
+  const userDataDir = path.join(cacheRoot, "chrome-profile");
+  const cookieFile = path.join(cacheRoot, "cookies.json");
+  const profileDbFile = path.join(cacheRoot, "profiles.db.json");
+
+  ensureDir(cacheRoot);
+  ensureDir(userDataDir);
+
+  return { safeSegment, userDataDir, cookieFile, profileDbFile };
+}
+
+function spawnNetflixScript(args, { env, label = "script", capture = false, onClose } = {}) {
+  const stdio = capture ? ["ignore", "pipe", "pipe"] : ["ignore", "inherit", "inherit"];
+  const child = spawn(process.execPath, args, {
+    env,
+    stdio,
+    detached: false,
+  });
+
+  let stdout = "";
+  let stderr = "";
+
+  if (capture) {
+    child.stdout.on("data", (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      process.stdout.write(`[netflixAutomation:${label}] ${text}`);
+    });
+    child.stderr.on("data", (chunk) => {
+      const text = chunk.toString();
+      stderr += text;
+      process.stderr.write(`[netflixAutomation:${label}] ${text}`);
+    });
+  }
+
+  child.on("error", (err) => {
+    console.error(`[netflixAutomation:${label}] Không thể khởi chạy script:`, err);
+    if (typeof onClose === "function") {
+      onClose({ code: null, error: err, stdout, stderr });
+    }
+  });
+
+  if (typeof onClose === "function") {
+    child.on("close", (code) => {
+      onClose({ code, stdout, stderr });
+    });
+  }
+
+  return child;
+}
+
+function buildAutomationEnv({
+  email,
+  password,
+  extraEnv = {},
+  userDataDir,
+  cookieFile,
+  profileDbFile,
+}) {
+  return {
+    ...process.env,
+    ...extraEnv,
+    NETFLIX_EMAIL: email,
+    NETFLIX_PASSWORD: password,
+    ACCOUNT_PASSWORD: password,
+    USER_DATA_DIR: userDataDir,
+    COOKIE_FILE: cookieFile,
+    PROFILE_DB_FILE: profileDbFile,
+  };
+}
+
 export function triggerNetflixAutomation(options = {}) {
   const {
     email,
@@ -39,37 +112,21 @@ export function triggerNetflixAutomation(options = {}) {
     return null;
   }
 
-  const safeSegment = sanitizeSegment(email);
-  const cacheRoot = path.resolve(backendRoot, ".netflix-cache", safeSegment);
-  const userDataDir = path.join(cacheRoot, "chrome-profile");
-  const cookieFile = path.join(cacheRoot, "cookies.json");
-  const profileDbFile = path.join(cacheRoot, "profiles.db.json");
-
-  ensureDir(cacheRoot);
-  ensureDir(userDataDir);
+  const { safeSegment, userDataDir, cookieFile, profileDbFile } = prepareAutomationContext(email);
+  const env = buildAutomationEnv({
+    email,
+    password,
+    extraEnv,
+    userDataDir,
+    cookieFile,
+    profileDbFile,
+  });
 
   const args = [scriptPath, "auto", trimmedProfile, pinString];
   if (isKids) args.push("--kids");
   if (hold) args.push("--hold");
 
-  const child = spawn(process.execPath, args, {
-    env: {
-      ...process.env,
-      ...extraEnv,
-      NETFLIX_EMAIL: email,
-      NETFLIX_PASSWORD: password,
-      ACCOUNT_PASSWORD: password,
-      USER_DATA_DIR: userDataDir,
-      COOKIE_FILE: cookieFile,
-      PROFILE_DB_FILE: profileDbFile,
-    },
-    stdio: ["ignore", "inherit", "inherit"],
-    detached: false,
-  });
-
-  child.on("error", (err) => {
-    console.error("[netflixAutomation] Không thể khởi chạy script:", err);
-  });
+  const child = spawnNetflixScript(args, { env, label: `auto:${safeSegment}` });
 
   child.on("close", (code) => {
     if (code === 0) {
@@ -84,6 +141,129 @@ export function triggerNetflixAutomation(options = {}) {
         `[netflixAutomation] Script kết thúc với mã ${code} cho ${email}`
       );
     }
+  });
+
+  return child;
+}
+
+function hasProfileNotFound(logText = "") {
+  const lower = logText.toLowerCase();
+  return (
+    lower.includes("không thấy hồ sơ") ||
+    lower.includes("khong thay ho so") ||
+    lower.includes("khong thay hồ sơ")
+  );
+}
+
+export function triggerNetflixProfileRename(options = {}) {
+  const {
+    email,
+    password,
+    currentProfileName,
+    newProfileName,
+    pin,
+    extraEnv = {},
+    hold = false,
+  } = options;
+
+  const trimmedCurrent = typeof currentProfileName === "string" ? currentProfileName.trim() : "";
+  const trimmedNew = typeof newProfileName === "string" ? newProfileName.trim() : "";
+  const pinString = typeof pin === "number" ? String(pin).padStart(4, "0") : String(pin || "");
+
+  if (!email || !password || !trimmedCurrent || !trimmedNew) {
+    console.warn("[netflixAutomation] Thiếu dữ liệu để đổi tên hồ sơ.");
+    return null;
+  }
+
+  const { safeSegment, userDataDir, cookieFile, profileDbFile } = prepareAutomationContext(email);
+  const env = buildAutomationEnv({
+    email,
+    password,
+    extraEnv,
+    userDataDir,
+    cookieFile,
+    profileDbFile,
+  });
+
+  const args = [scriptPath, "rename", trimmedCurrent, trimmedNew];
+  if (/^\d{4}$/.test(pinString)) args.push(pinString);
+  if (hold) args.push("--hold");
+
+  const child = spawnNetflixScript(args, {
+    env,
+    label: `rename:${safeSegment}`,
+    capture: true,
+    onClose: ({ code, stdout = "", stderr = "" }) => {
+      if (code === 0) {
+        console.info(
+          `[netflixAutomation] Đã đổi tên hồ sơ ${trimmedCurrent} -> ${trimmedNew} cho ${email}`
+        );
+        return;
+      }
+
+      const combined = `${stdout}\n${stderr}`;
+      console.warn(
+        `[netflixAutomation] Đổi tên hồ sơ thất bại (mã ${code}) cho ${email}`
+      );
+
+      if (hasProfileNotFound(combined) && /^\d{4}$/.test(pinString)) {
+        console.warn(
+          `[netflixAutomation] Không tìm thấy hồ sơ cũ – thử tạo lại bằng auto flow...`
+        );
+        triggerNetflixAutomation({
+          email,
+          password,
+          profileName: trimmedNew,
+          pin: pinString,
+          extraEnv,
+          hold,
+        });
+      }
+    },
+  });
+
+  return child;
+}
+
+export function triggerNetflixPinUpdate(options = {}) {
+  const { email, password, profileName, pin, extraEnv = {}, hold = false } = options;
+
+  const trimmedProfile = typeof profileName === "string" ? profileName.trim() : "";
+  const pinString = typeof pin === "number" ? String(pin).padStart(4, "0") : String(pin || "");
+
+  if (!email || !password || !trimmedProfile || !/^\d{4}$/.test(pinString)) {
+    console.warn("[netflixAutomation] Thiếu dữ liệu để đổi PIN hồ sơ.");
+    return null;
+  }
+
+  const { safeSegment, userDataDir, cookieFile, profileDbFile } = prepareAutomationContext(email);
+  const env = buildAutomationEnv({
+    email,
+    password,
+    extraEnv,
+    userDataDir,
+    cookieFile,
+    profileDbFile,
+  });
+
+  const args = [scriptPath, trimmedProfile, pinString];
+  if (hold) args.push("--hold");
+
+  const child = spawnNetflixScript(args, {
+    env,
+    label: `pin:${safeSegment}`,
+    capture: true,
+    onClose: ({ code }) => {
+      if (code === 0) {
+        console.info(
+          `[netflixAutomation] Đã cập nhật PIN cho hồ sơ ${trimmedProfile} của ${email}`
+        );
+      } else {
+        console.warn(
+          `[netflixAutomation] Đổi PIN thất bại (mã ${code}) cho ${email}`
+        );
+      }
+    },
   });
 
   return child;


### PR DESCRIPTION
## Summary
- add reusable helpers to the Netflix automation service for spawning scripts, renaming profiles, and updating PINs with logging
- invoke the rename automation when customers change a profile name, and recreate the profile automatically if the old name no longer exists
- invoke the PIN update automation whenever customers update their Netflix profile PIN from order history

## Testing
- npm --prefix backend test *(fails: Jest decorator parsing error in existing test fixture)*

------
https://chatgpt.com/codex/tasks/task_e_68d0c7762bf48324b2c8e58338d440af