### PR TITLE
Ensure default customer name before balance updates

### DIFF
--- a/backend/controllers/account50kController.js
+++ b/backend/controllers/account50kController.js
@@ -577,6 +577,9 @@ export const buyAccountGTK = async (req, res) => {
 
     // 4. Trừ tiền user
     customer.amount -= amount;
+    if (!customer.name) {
+      customer.name = "Khách mới";
+    }
     await customer.save();
 
     // 5. Tạo Order mới

--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -133,6 +133,9 @@ export const localSavings = async (req, res) => {
     }
 
     customer.amount -= amountNum;
+    if (!customer.name) {
+      customer.name = "Khách mới";
+    }
     await customer.save();
 
     const newOrder = await Order.create({

--- a/backend/models/Customer.js
+++ b/backend/models/Customer.js
@@ -2,7 +2,7 @@ import mongoose from "mongoose";
 
 const customerSchema = new mongoose.Schema({
   phone: { type: String, required: true, unique: true },
-  name: { type: String, required: true },
+  name: { type: String, required: true, default: "Khách mới" },
   amount: { type: Number, default: 0 },
   pin: { type: String, required: true },
 }, { timestamps: true });


### PR DESCRIPTION
## Summary
- ensure GTK purchase flows restore a default customer name before saving balance updates
- assign a default value for the customer name field at the schema level to cover future records

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d66b37453883248d721189999b5cd2