### PR TITLE
Revamp admin orders layout

### DIFF
--- a/frontend/src/admin/Admin.css
+++ b/frontend/src/admin/Admin.css
@@ -621,6 +621,149 @@
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
 }
 
+.orders-card {
+  padding: clamp(2rem, 2vw + 1.5rem, 2.75rem);
+}
+
+.orders-hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: flex-start;
+  margin-bottom: 2.5rem;
+}
+
+.orders-title {
+  margin: 0;
+  font-size: clamp(2rem, 2.8vw, 2.6rem);
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.orders-subtitle {
+  margin-top: 0.75rem;
+  max-width: 520px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.orders-quick-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+  background: linear-gradient(135deg, rgba(229, 9, 20, 0.08), rgba(15, 23, 42, 0.06));
+  border-radius: 1rem;
+  border: 1px solid rgba(229, 9, 20, 0.08);
+}
+
+.orders-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.orders-stat-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.orders-stat-value {
+  font-size: 1.6rem;
+  color: var(--text-color);
+  line-height: 1;
+}
+
+.orders-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  align-items: end;
+  margin-bottom: 2rem;
+}
+
+.orders-search-group,
+.orders-filter-group,
+.orders-submit-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.orders-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.input-shell {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 14px 28px rgba(15, 23, 42, 0.08);
+}
+
+.input-shell input {
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  width: 100%;
+  color: var(--text-color);
+}
+
+.input-shell input:focus {
+  outline: none;
+}
+
+.input-shell-icon {
+  color: rgba(15, 23, 42, 0.4);
+}
+
+.filter-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.filter-chip {
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  background: rgba(248, 250, 252, 0.9);
+  color: var(--text-color);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition-speed), box-shadow var(--transition-speed),
+    background var(--transition-speed), color var(--transition-speed);
+}
+
+.filter-chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.08);
+}
+
+.filter-chip.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+  box-shadow: 0 18px 28px rgba(229, 9, 20, 0.3);
+}
+
+.orders-table-container {
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
 .surface-header,
 .admin-header {
   display: flex;
@@ -711,18 +854,18 @@
 
 .data-table th,
 .table th {
-  padding: 0.9rem 1.1rem;
+  padding: 1.1rem 1.25rem;
   text-align: left;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.55);
+  color: rgba(15, 23, 42, 0.6);
   border-bottom: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .data-table td,
 .table td {
-  padding: 1rem 1.1rem;
+  padding: 1.1rem 1.25rem;
   border-bottom: 1px solid rgba(15, 23, 42, 0.05);
   background: #fff;
 }
@@ -735,6 +878,41 @@
 .data-table tbody tr:hover td,
 .table tbody tr:hover td {
   background: rgba(229, 9, 20, 0.08);
+}
+
+.plan-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.plan-badge::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+}
+
+.plan-badge-premium {
+  background: rgba(229, 9, 20, 0.12);
+  color: var(--primary-dark);
+}
+
+.plan-badge-premium::before {
+  background: var(--primary);
+}
+
+.plan-badge-saving {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.plan-badge-saving::before {
+  background: #2563eb;
 }
 
 .customer-cell {
@@ -866,6 +1044,10 @@
   .admin-topbar {
     padding: 1.25rem 2rem;
   }
+
+  .orders-quick-stats {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
 }
 
 @media (max-width: 900px) {
@@ -902,6 +1084,18 @@
 
   .admin-main {
     min-height: calc(100vh - 90px);
+  }
+
+  .orders-hero {
+    flex-direction: column;
+  }
+
+  .orders-quick-stats {
+    width: 100%;
+  }
+
+  .orders-controls {
+    grid-template-columns: 1fr 1fr;
   }
 }
 
@@ -949,6 +1143,15 @@
     flex-direction: column;
     align-items: stretch;
   }
+
+  .orders-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .orders-quick-stats {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+    gap: 0.75rem;
+  }
 }
 
 @media (max-width: 540px) {
@@ -962,5 +1165,19 @@
 
   .stat-card {
     padding: 1.25rem;
+  }
+
+  .orders-card {
+    padding: 1.75rem;
+  }
+
+  .orders-quick-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .orders-stat {
+    padding: 0.75rem;
+    background: rgba(248, 250, 252, 0.88);
+    border-radius: 0.85rem;
   }
 }

--- a/frontend/src/admin/AdminOrders.jsx
+++ b/frontend/src/admin/AdminOrders.jsx
@@ -143,6 +143,31 @@ export default function AdminOrders() {
     setShowDelete(false);
   };
 
+  const planFilterOptions = useMemo(
+    () => [
+      { value: 'all', label: 'Tất cả gói' },
+      { value: 'Gói tiết kiệm', label: 'Gói tiết kiệm' },
+      { value: 'Gói cao cấp', label: 'Gói cao cấp' },
+    ],
+    []
+  );
+
+  const stats = useMemo(() => {
+    const premiumCount = orders.filter(o => o.plan === 'Gói cao cấp').length;
+    const savingCount = orders.filter(o => o.plan === 'Gói tiết kiệm').length;
+    const activeCount = orders.filter(o => {
+      const expires = getExpiry(o);
+      return expires.getTime() > Date.now();
+    }).length;
+
+    return {
+      totalOrders: orders.length,
+      premiumCount,
+      savingCount,
+      activeCount,
+    };
+  }, [orders]);
+
   const sorted = useMemo(() => {
     const getValue = o => {
       if (sortField === 'orderCode') {
@@ -176,35 +201,101 @@ export default function AdminOrders() {
 
   return (
     <AdminLayout>
-      <div className="card">
-        <header className="admin-header">
-          <h1 className="text-xl font-semibold">Quản lý đơn hàng</h1>
-        </header>
-        <form onSubmit={handleSearch} className="form-search">
-          <input
-            type="text"
-            placeholder="Tìm theo SĐT"
-            value={phone}
-            onChange={e => setPhone(e.target.value)}
-            className="input"
-          />
-          <select
-            value={planFilter}
-            onChange={e => {
-              setPlanFilter(e.target.value);
-              setPage(1);
-            }}
-            className="input"
-          >
-            <option value="all">Tất cả gói</option>
-            <option value="Gói cao cấp">Gói cao cấp</option>
-            <option value="Gói tiết kiệm">Gói tiết kiệm</option>
-          </select>
-          <button type="submit" className="btn btn-primary">
-            Tìm kiếm
-          </button>
+      <div className="card orders-card">
+        <section className="orders-hero">
+          <div>
+            <h1 className="orders-title">Quản lý đơn hàng</h1>
+            <p className="orders-subtitle">
+              Theo dõi trạng thái, tìm kiếm nhanh theo số điện thoại và quản lý các gói dịch vụ.
+            </p>
+          </div>
+          <div className="orders-quick-stats">
+            <div className="orders-stat">
+              <span className="orders-stat-label">Tổng đơn</span>
+              <strong className="orders-stat-value">{stats.totalOrders}</strong>
+            </div>
+            <div className="orders-stat">
+              <span className="orders-stat-label">Đang hoạt động</span>
+              <strong className="orders-stat-value">{stats.activeCount}</strong>
+            </div>
+            <div className="orders-stat">
+              <span className="orders-stat-label">Gói cao cấp</span>
+              <strong className="orders-stat-value">{stats.premiumCount}</strong>
+            </div>
+            <div className="orders-stat">
+              <span className="orders-stat-label">Gói tiết kiệm</span>
+              <strong className="orders-stat-value">{stats.savingCount}</strong>
+            </div>
+          </div>
+        </section>
+
+        <form onSubmit={handleSearch} className="orders-controls">
+          <div className="orders-search-group">
+            <label htmlFor="order-search" className="orders-label">
+              Tìm theo SĐT
+            </label>
+            <div className="input-shell">
+              <svg
+                aria-hidden="true"
+                className="input-shell-icon"
+                fill="none"
+                height="20"
+                viewBox="0 0 24 24"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15.5 15.5L21 21"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                />
+                <path
+                  d="M17 10.5C17 14.0899 14.0899 17 10.5 17C6.91015 17 4 14.0899 4 10.5C4 6.91015 6.91015 4 10.5 4C14.0899 4 17 6.91015 17 10.5Z"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                />
+              </svg>
+              <input
+                id="order-search"
+                type="text"
+                placeholder="Nhập số điện thoại khách hàng"
+                value={phone}
+                onChange={e => setPhone(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="orders-filter-group">
+            <span className="orders-label">Lọc theo gói</span>
+            <div className="filter-chip-group" role="group" aria-label="Lọc theo gói dịch vụ">
+              {planFilterOptions.map(option => (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={`filter-chip ${planFilter === option.value ? 'active' : ''}`}
+                  onClick={() => {
+                    setPlanFilter(option.value);
+                    setPage(1);
+                  }}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="orders-submit-group">
+            <button type="submit" className="btn btn-primary">
+              Tìm kiếm
+            </button>
+          </div>
         </form>
-        <div className="table-container">
+
+        <div className="table-container orders-table-container">
           <table className="table">
             <thead>
               <tr>
@@ -241,7 +332,15 @@ export default function AdminOrders() {
                       </button>
                     </td>
                     <td>{o.user?.phone || ''}</td>
-                    <td>{o.plan}</td>
+                    <td>
+                      <span
+                        className={`plan-badge ${
+                          o.plan === 'Gói cao cấp' ? 'plan-badge-premium' : 'plan-badge-saving'
+                        }`}
+                      >
+                        {o.plan}
+                      </span>
+                    </td>
                     <td>{new Date(o.purchaseDate).toLocaleDateString('vi-VN')}</td>
                     <td>{expires.toLocaleDateString('vi-VN')}</td>
                     <td>{left > 0 ? left : 'Đã hết hạn'}</td>


### PR DESCRIPTION
## Summary
- redesign the admin orders screen with a larger hero, quick stats, and segmented plan filters
- refresh table styling with prominent plan badges and roomier spacing for easier reading

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac1f1dfd08324b0cb3a55d17a60df