### PR TITLE
Enhance admin orders layout

### DIFF
--- a/frontend/src/admin/Admin.css
+++ b/frontend/src/admin/Admin.css
@@ -280,11 +280,12 @@
 }
 
 .admin-content {
-  padding: 2.5rem;
-  max-width: 1200px;
+  padding: 2.5rem 2.75rem 3.25rem;
   width: 100%;
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
   flex: 1;
+  align-self: stretch;
 }
 
 /* ============================
@@ -621,6 +622,295 @@
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
 }
 
+.orders-card {
+  padding: clamp(2.25rem, 2.6vw + 1.5rem, 3rem);
+  width: 100%;
+}
+
+.orders-hero {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 2rem;
+  align-items: flex-start;
+  margin-bottom: 2.5rem;
+}
+
+.orders-title {
+  margin: 0;
+  font-size: clamp(2rem, 2.8vw, 2.6rem);
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.orders-subtitle {
+  margin-top: 0.75rem;
+  max-width: 520px;
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.orders-quick-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(120px, 1fr));
+  gap: 1rem;
+  padding: 1rem;
+  background: linear-gradient(135deg, rgba(229, 9, 20, 0.08), rgba(15, 23, 42, 0.06));
+  border-radius: 1rem;
+  border: 1px solid rgba(229, 9, 20, 0.08);
+}
+
+.orders-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.orders-stat-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.orders-stat-value {
+  font-size: 1.6rem;
+  color: var(--text-color);
+  line-height: 1;
+}
+
+.orders-plan-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+}
+
+.plan-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  border-radius: 1.25rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: var(--surface-muted);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.plan-card::after {
+  content: '';
+  position: absolute;
+  inset: auto -50% -65% auto;
+  width: 240px;
+  height: 240px;
+  background: radial-gradient(circle, rgba(229, 9, 20, 0.18), transparent 70%);
+  opacity: 0;
+  transition: opacity var(--transition-speed);
+  pointer-events: none;
+}
+
+.plan-card:hover::after {
+  opacity: 1;
+}
+
+.plan-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.plan-card-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: rgba(229, 9, 20, 0.12);
+  color: var(--text-color);
+}
+
+.plan-card-percentage {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.6);
+  font-weight: 500;
+}
+
+.plan-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.plan-card-total {
+  margin: 0;
+  font-size: clamp(2.25rem, 2.3vw, 2.6rem);
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.plan-card-total-label {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.55);
+  font-size: 0.95rem;
+}
+
+.plan-card-metrics {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 0;
+}
+
+.plan-card-metrics div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.plan-card-metrics dt {
+  margin: 0;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.plan-card-metrics dd {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.plan-card-progress {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  overflow: hidden;
+}
+
+.plan-card-progress span {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(229, 9, 20, 0.75), rgba(229, 9, 20, 0.45));
+}
+
+.plan-card-saving .plan-card-chip {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.plan-card-saving .plan-card-progress span {
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.7), rgba(59, 130, 246, 0.5));
+}
+
+.plan-card-premium .plan-card-chip {
+  background: rgba(229, 9, 20, 0.18);
+  color: var(--primary-dark);
+}
+
+.plan-card-premium .plan-card-progress span {
+  background: linear-gradient(90deg, rgba(229, 9, 20, 0.85), rgba(229, 9, 20, 0.55));
+}
+
+.orders-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  align-items: end;
+  margin-bottom: 2rem;
+}
+
+.orders-search-group,
+.orders-filter-group,
+.orders-submit-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.orders-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.input-shell {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(248, 250, 252, 0.9);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 14px 28px rgba(15, 23, 42, 0.08);
+}
+
+.input-shell input {
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  width: 100%;
+  color: var(--text-color);
+}
+
+.input-shell input:focus {
+  outline: none;
+}
+
+.input-shell-icon {
+  color: rgba(15, 23, 42, 0.4);
+}
+
+.filter-chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.filter-chip {
+  padding: 0.65rem 1.2rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.1);
+  background: rgba(248, 250, 252, 0.9);
+  color: var(--text-color);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--transition-speed), box-shadow var(--transition-speed),
+    background var(--transition-speed), color var(--transition-speed);
+}
+
+.filter-chip:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(15, 23, 42, 0.08);
+}
+
+.filter-chip.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+  box-shadow: 0 18px 28px rgba(229, 9, 20, 0.3);
+}
+
+.orders-table-container {
+  border-radius: 1.25rem;
+  overflow: hidden;
+}
+
 .surface-header,
 .admin-header {
   display: flex;
@@ -711,18 +1001,18 @@
 
 .data-table th,
 .table th {
-  padding: 0.9rem 1.1rem;
+  padding: 1.1rem 1.25rem;
   text-align: left;
-  font-size: 0.78rem;
-  letter-spacing: 0.08em;
+  font-size: 0.82rem;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.55);
+  color: rgba(15, 23, 42, 0.6);
   border-bottom: 1px solid rgba(15, 23, 42, 0.08);
 }
 
 .data-table td,
 .table td {
-  padding: 1rem 1.1rem;
+  padding: 1.1rem 1.25rem;
   border-bottom: 1px solid rgba(15, 23, 42, 0.05);
   background: #fff;
 }
@@ -735,6 +1025,41 @@
 .data-table tbody tr:hover td,
 .table tbody tr:hover td {
   background: rgba(229, 9, 20, 0.08);
+}
+
+.plan-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.95rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.plan-badge::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+}
+
+.plan-badge-premium {
+  background: rgba(229, 9, 20, 0.12);
+  color: var(--primary-dark);
+}
+
+.plan-badge-premium::before {
+  background: var(--primary);
+}
+
+.plan-badge-saving {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+.plan-badge-saving::before {
+  background: #2563eb;
 }
 
 .customer-cell {
@@ -866,6 +1191,18 @@
   .admin-topbar {
     padding: 1.25rem 2rem;
   }
+
+  .admin-content {
+    padding: 2.25rem 2rem 3rem;
+  }
+
+  .orders-quick-stats {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+  }
+
+  .orders-plan-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
 }
 
 @media (max-width: 900px) {
@@ -902,6 +1239,26 @@
 
   .admin-main {
     min-height: calc(100vh - 90px);
+  }
+
+  .admin-content {
+    padding: 2rem 1.75rem 2.75rem;
+  }
+
+  .orders-hero {
+    flex-direction: column;
+  }
+
+  .orders-quick-stats {
+    width: 100%;
+  }
+
+  .orders-plan-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+
+  .orders-controls {
+    grid-template-columns: 1fr 1fr;
   }
 }
 
@@ -949,6 +1306,23 @@
     flex-direction: column;
     align-items: stretch;
   }
+
+  .orders-controls {
+    grid-template-columns: 1fr;
+  }
+
+  .orders-quick-stats {
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .plan-card {
+    padding: 1.5rem;
+  }
+
+  .plan-card-metrics {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 540px) {
@@ -962,5 +1336,27 @@
 
   .stat-card {
     padding: 1.25rem;
+  }
+
+  .orders-card {
+    padding: 1.75rem;
+  }
+
+  .orders-quick-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .orders-stat {
+    padding: 0.75rem;
+    background: rgba(248, 250, 252, 0.88);
+    border-radius: 0.85rem;
+  }
+
+  .orders-plan-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .plan-card {
+    gap: 1.1rem;
   }
 }

--- a/frontend/src/admin/AdminOrders.jsx
+++ b/frontend/src/admin/AdminOrders.jsx
@@ -143,6 +143,73 @@ export default function AdminOrders() {
     setShowDelete(false);
   };
 
+  const planFilterOptions = useMemo(
+    () => [
+      { value: 'all', label: 'Tất cả gói' },
+      { value: 'Gói tiết kiệm', label: 'Gói tiết kiệm' },
+      { value: 'Gói cao cấp', label: 'Gói cao cấp' },
+    ],
+    []
+  );
+
+  const stats = useMemo(() => {
+    const premiumOrders = orders.filter(o => o.plan === 'Gói cao cấp');
+    const savingOrders = orders.filter(o => o.plan === 'Gói tiết kiệm');
+    const premiumCount = premiumOrders.length;
+    const savingCount = savingOrders.length;
+    const activeCount = orders.filter(o => {
+      const expires = getExpiry(o);
+      return expires.getTime() > Date.now();
+    }).length;
+
+    return {
+      totalOrders: orders.length,
+      premiumCount,
+      savingCount,
+      activeCount,
+      premiumActive: premiumOrders.filter(o => daysLeft(o) > 0).length,
+      savingActive: savingOrders.filter(o => daysLeft(o) > 0).length,
+      premiumExpiring: premiumOrders.filter(o => {
+        const left = daysLeft(o);
+        return left > 0 && left <= 7;
+      }).length,
+      savingExpiring: savingOrders.filter(o => {
+        const left = daysLeft(o);
+        return left > 0 && left <= 7;
+      }).length,
+    };
+  }, [orders]);
+
+  const planHighlights = useMemo(() => {
+    const total = orders.length || 1;
+    return [
+      {
+        key: 'saving',
+        name: 'Gói tiết kiệm',
+        total: stats.savingCount,
+        active: stats.savingActive,
+        expiringSoon: stats.savingExpiring,
+        percentage: Math.round((stats.savingCount / total) * 100),
+      },
+      {
+        key: 'premium',
+        name: 'Gói cao cấp',
+        total: stats.premiumCount,
+        active: stats.premiumActive,
+        expiringSoon: stats.premiumExpiring,
+        percentage: Math.round((stats.premiumCount / total) * 100),
+      },
+    ];
+  }, [
+    orders.length,
+    stats.savingCount,
+    stats.premiumCount,
+    stats.savingActive,
+    stats.premiumActive,
+    stats.savingExpiring,
+    stats.premiumExpiring,
+  ]);
+
   const sorted = useMemo(() => {
     const getValue = o => {
       if (sortField === 'orderCode') {
@@ -176,35 +243,137 @@ export default function AdminOrders() {
 
   return (
     <AdminLayout>
-      <div className="card">
-        <header className="admin-header">
-          <h1 className="text-xl font-semibold">Quản lý đơn hàng</h1>
-        </header>
-        <form onSubmit={handleSearch} className="form-search">
-          <input
-            type="text"
-            placeholder="Tìm theo SĐT"
-            value={phone}
-            onChange={e => setPhone(e.target.value)}
-            className="input"
-          />
-          <select
-            value={planFilter}
-            onChange={e => {
-              setPlanFilter(e.target.value);
-              setPage(1);
-            }}
-            className="input"
-          >
-            <option value="all">Tất cả gói</option>
-            <option value="Gói cao cấp">Gói cao cấp</option>
-            <option value="Gói tiết kiệm">Gói tiết kiệm</option>
-          </select>
-          <button type="submit" className="btn btn-primary">
-            Tìm kiếm
-          </button>
+      <div className="card orders-card">
+        <section className="orders-hero">
+          <div>
+            <h1 className="orders-title">Quản lý đơn hàng</h1>
+            <p className="orders-subtitle">
+              Theo dõi trạng thái, tìm kiếm nhanh theo số điện thoại và quản lý các gói dịch vụ.
+            </p>
+          </div>
+          <div className="orders-quick-stats">
+            <div className="orders-stat">
+              <span className="orders-stat-label">Tổng đơn</span>
+              <strong className="orders-stat-value">{stats.totalOrders}</strong>
+            </div>
+            <div className="orders-stat">
+              <span className="orders-stat-label">Đang hoạt động</span>
+              <strong className="orders-stat-value">{stats.activeCount}</strong>
+            </div>
+            <div className="orders-stat">
+              <span className="orders-stat-label">Gói cao cấp</span>
+              <strong className="orders-stat-value">{stats.premiumCount}</strong>
+            </div>
+            <div className="orders-stat">
+              <span className="orders-stat-label">Gói tiết kiệm</span>
+              <strong className="orders-stat-value">{stats.savingCount}</strong>
+            </div>
+          </div>
+        </section>
+
+        <section className="orders-plan-grid" aria-label="Tổng quan gói dịch vụ">
+          {planHighlights.map(plan => (
+            <article key={plan.key} className={`plan-card plan-card-${plan.key}`}>
+              <header className="plan-card-header">
+                <div className="plan-card-chip">{plan.name}</div>
+                <span className="plan-card-percentage">{plan.percentage}% tổng đơn</span>
+              </header>
+              <div className="plan-card-body">
+                <p className="plan-card-total">{plan.total}</p>
+                <p className="plan-card-total-label">đơn hàng đã ghi nhận</p>
+                <dl className="plan-card-metrics">
+                  <div>
+                    <dt>Đang hoạt động</dt>
+                    <dd>{plan.active}</dd>
+                  </div>
+                  <div>
+                    <dt>Sắp hết hạn (≤7 ngày)</dt>
+                    <dd>{plan.expiringSoon}</dd>
+                  </div>
+                </dl>
+              </div>
+              <div className="plan-card-progress" role="presentation">
+                <span
+                  aria-hidden="true"
+                  style={{
+                    width: `${Math.min(
+                      100,
+                      plan.percentage > 0 ? Math.max(plan.percentage, 12) : 6
+                    )}%`,
+                  }}
+                />
+              </div>
+            </article>
+          ))}
+        </section>
+
+        <form onSubmit={handleSearch} className="orders-controls">
+          <div className="orders-search-group">
+            <label htmlFor="order-search" className="orders-label">
+              Tìm theo SĐT
+            </label>
+            <div className="input-shell">
+              <svg
+                aria-hidden="true"
+                className="input-shell-icon"
+                fill="none"
+                height="20"
+                viewBox="0 0 24 24"
+                width="20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15.5 15.5L21 21"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                />
+                <path
+                  d="M17 10.5C17 14.0899 14.0899 17 10.5 17C6.91015 17 4 14.0899 4 10.5C4 6.91015 6.91015 4 10.5 4C14.0899 4 17 6.91015 17 10.5Z"
+                  stroke="currentColor"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1.5"
+                />
+              </svg>
+              <input
+                id="order-search"
+                type="text"
+                placeholder="Nhập số điện thoại khách hàng"
+                value={phone}
+                onChange={e => setPhone(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="orders-filter-group">
+            <span className="orders-label">Lọc theo gói</span>
+            <div className="filter-chip-group" role="group" aria-label="Lọc theo gói dịch vụ">
+              {planFilterOptions.map(option => (
+                <button
+                  key={option.value}
+                  type="button"
+                  className={`filter-chip ${planFilter === option.value ? 'active' : ''}`}
+                  onClick={() => {
+                    setPlanFilter(option.value);
+                    setPage(1);
+                  }}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="orders-submit-group">
+            <button type="submit" className="btn btn-primary">
+              Tìm kiếm
+            </button>
+          </div>
         </form>
-        <div className="table-container">
+
+        <div className="table-container orders-table-container">
           <table className="table">
             <thead>
               <tr>
@@ -241,7 +410,15 @@ export default function AdminOrders() {
                       </button>
                     </td>
                     <td>{o.user?.phone || ''}</td>
-                    <td>{o.plan}</td>
+                    <td>
+                      <span
+                        className={`plan-badge ${
+                          o.plan === 'Gói cao cấp' ? 'plan-badge-premium' : 'plan-badge-saving'
+                        }`}
+                      >
+                        {o.plan}
+                      </span>
+                    </td>
                     <td>{new Date(o.purchaseDate).toLocaleDateString('vi-VN')}</td>
                     <td>{expires.toLocaleDateString('vi-VN')}</td>
                     <td>{left > 0 ? left : 'Đã hết hạn'}</td>


### PR DESCRIPTION
## Summary
- add plan highlight cards to the admin orders view so each plan feels larger and more informative
- extend the admin styles with plan card visuals and responsive tweaks for the new overview section

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dac1f1dfd08324b0cb3a55d17a60df