### PR TITLE
Fix admin cards full width

### DIFF
--- a/frontend/src/admin/Admin.css
+++ b/frontend/src/admin/Admin.css
@@ -613,6 +613,7 @@
    Data Surfaces & Tables
    ============================ */
 
+
 .surface-card,
 .card {
   background: var(--surface);
@@ -620,6 +621,14 @@
   padding: 2rem;
   border: 1px solid rgba(15, 23, 42, 0.05);
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+}
+
+/* Ensure admin content cards stretch the full available width, overriding the
+   generic `.card` styles defined in the client application shell. */
+.admin-content .card {
+  max-width: none;
+  width: 100%;
+  margin: 0 0 2rem;
 }
 
 .orders-card {


### PR DESCRIPTION
## Summary
- override the global card width inside the admin layout so management pages use the full content width

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db8007988083249f2c923c43cada75