### PR TITLE
Enhance premium account modal styling

### DIFF
--- a/frontend/src/admin/Admin.css
+++ b/frontend/src/admin/Admin.css
@@ -327,6 +327,16 @@
   background: var(--primary-dark);
 }
 
+.btn-secondary {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text-color);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.08);
+}
+
+.btn-secondary:hover:not(:disabled) {
+  background: rgba(15, 23, 42, 0.12);
+}
+
 .btn-soft {
   background: var(--primary-soft);
   color: var(--primary);
@@ -343,6 +353,12 @@
 
 .btn-ghost:hover:not(:disabled) {
   background: rgba(15, 23, 42, 0.08);
+}
+
+.btn-sm {
+  padding: 0.45rem 0.9rem;
+  font-size: 0.85rem;
+  border-radius: 0.65rem;
 }
 
 .btn-outline {
@@ -613,6 +629,7 @@
    Data Surfaces & Tables
    ============================ */
 
+
 .surface-card,
 .card {
   background: var(--surface);
@@ -620,6 +637,14 @@
   padding: 2rem;
   border: 1px solid rgba(15, 23, 42, 0.05);
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+}
+
+/* Ensure admin content cards stretch the full available width, overriding the
+   generic `.card` styles defined in the client application shell. */
+.admin-content .card {
+  max-width: none;
+  width: 100%;
+  margin: 0 0 2rem;
 }
 
 .orders-card {
@@ -963,6 +988,18 @@
   gap: 0.5rem;
 }
 
+.text-center {
+  text-align: center !important;
+}
+
+.modal-profile-actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
 .empty-state {
   text-align: center;
   padding: 2.5rem 1rem;
@@ -1030,9 +1067,109 @@
   background: var(--surface);
   padding: 2rem;
   border-radius: var(--card-radius);
-  max-width: 520px;
-  width: 92%;
+  max-width: min(960px, calc(100% - 3rem));
+  width: 100%;
   box-shadow: var(--shadow-soft);
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  margin-bottom: 1.75rem;
+}
+
+.modal-title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text-color);
+}
+
+.modal-subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.modal-close {
+  padding: 0.4rem;
+  border-radius: 999px;
+  width: 38px;
+  height: 38px;
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.modal-close:hover:not(:disabled) {
+  background: rgba(15, 23, 42, 0.12);
+}
+
+.modal-body {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.modal-table {
+  border: 1px solid var(--border-color);
+  border-radius: calc(var(--card-radius) - 0.35rem);
+  overflow: auto;
+  background: var(--surface-muted);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.modal-table .table {
+  min-width: 680px;
+}
+
+.modal-table .table th,
+.modal-table .table td {
+  padding: 0.85rem 1.1rem;
+}
+
+.modal-table .table tbody tr:hover td {
+  background: rgba(229, 9, 20, 0.12);
+}
+
+.modal-footer {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.input-inline {
+  width: 100%;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  background: rgba(248, 250, 252, 0.9);
+  border-radius: 0.7rem;
+  padding: 0.45rem 0.75rem;
+  font-size: 0.92rem;
+  transition: border-color var(--transition-speed),
+    box-shadow var(--transition-speed), background var(--transition-speed);
+}
+
+.input-inline:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-soft);
+  background: #fff;
+}
+
+.modal--accounts .modal-table .table td:nth-child(3),
+.modal--accounts .modal-table .table td:nth-child(4),
+.modal--accounts .modal-table .table td:nth-child(5),
+.modal--accounts .modal-table .table th:nth-child(3),
+.modal--accounts .modal-table .table th:nth-child(4),
+.modal--accounts .modal-table .table th:nth-child(5) {
+  white-space: nowrap;
 }
 
 /* ============================

--- a/frontend/src/admin/AdminNetflixAccounts.jsx
+++ b/frontend/src/admin/AdminNetflixAccounts.jsx
@@ -15,6 +15,11 @@ export default function AdminNetflixAccounts() {
   const [selected, setSelected] = useState(null);
   const [profileEdits, setProfileEdits] = useState({});
 
+  const selectedProfileCount = selected ? selected.profiles.length : 0;
+  const selectedUsedCount = selected
+    ? selected.profiles.filter(p => p.status === 'used').length
+    : 0;
+
   const fetchAccounts = useCallback(async () => {
     try {
       const { data } = await axios.get('/api/admin/netflix-accounts', {
@@ -264,78 +269,111 @@ export default function AdminNetflixAccounts() {
 
         {selected && (
           <div className="modal-backdrop" onClick={() => setSelected(null)}>
-            <div className="modal" onClick={e => e.stopPropagation()}>
-              <h2 className="mb-2">Hồ sơ của {selected.email}</h2>
-              <table className="table">
-                <thead>
-                  <tr>
-                    <th>Tên hồ sơ</th>
-                    <th>Mã Pin</th>
-                    <th>SDT khách</th>
-                    <th>Ngày mua</th>
-                    <th>Ngày hết hạn</th>
-                    <th>Hành động</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {selected.profiles.map(p => (
-                    <tr key={p.id}>
-                      <td>
-                        <input
-                          type="text"
-                          value={
-                            profileEdits[p.id]?.name ?? p.name ?? ''
-                          }
-                          onChange={e =>
-                            handleProfileChange(p.id, 'name', e.target.value)
-                          }
-                          onBlur={() => saveProfile(p.id)}
-                          className="input"
-                        />
-                      </td>
-                      <td>
-                        <input
-                          type="text"
-                          value={profileEdits[p.id]?.pin ?? p.pin ?? ''}
-                          onChange={e =>
-                            handleProfileChange(p.id, 'pin', e.target.value)
-                          }
-                          onBlur={() => saveProfile(p.id)}
-                          className="input"
-                        />
-                      </td>
-                      <td>{p.customerPhone || '-'}</td>
-                      <td>
-                        {p.purchaseDate
-                          ? new Date(p.purchaseDate).toLocaleDateString()
-                          : '-'}
-                      </td>
-                      <td>
-                        {p.expirationDate
-                          ? new Date(p.expirationDate).toLocaleDateString()
-                          : '-'}
-                      </td>
-                      <td className="text-center">
-                        <button
-                          onClick={() => handleProfileDelete(p.id)}
-                          className="btn btn-danger mr-2"
-                        >
-                          Xóa
-                        </button>
-                        <button
-                          onClick={() => handleProfileTransfer(p.id)}
-                          className="btn btn-secondary"
-                        >
-                          Chuyển
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-              <button onClick={() => setSelected(null)} className="btn mt-4">
-                Đóng
-              </button>
+            <div
+              className="modal modal--accounts"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="modal-header">
+                <div>
+                  <h2 className="modal-title">Hồ sơ của {selected.email}</h2>
+                  <p className="modal-subtitle">
+                    {selected.plan} · {selectedUsedCount}/{selectedProfileCount} hồ
+                    sơ đã dùng
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-ghost modal-close"
+                  onClick={() => setSelected(null)}
+                  aria-label="Đóng"
+                >
+                  ×
+                </button>
+              </div>
+
+              <div className="modal-body">
+                <div className="modal-table">
+                  <table className="table table--profiles">
+                    <thead>
+                      <tr>
+                        <th>Tên hồ sơ</th>
+                        <th>Mã Pin</th>
+                        <th>SDT khách</th>
+                        <th>Ngày mua</th>
+                        <th>Ngày hết hạn</th>
+                        <th className="text-center">Hành động</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {selected.profiles.map(p => (
+                        <tr key={p.id}>
+                          <td>
+                            <input
+                              type="text"
+                              value={
+                                profileEdits[p.id]?.name ?? p.name ?? ''
+                              }
+                              onChange={e =>
+                                handleProfileChange(p.id, 'name', e.target.value)
+                              }
+                              onBlur={() => saveProfile(p.id)}
+                              className="input input-inline"
+                            />
+                          </td>
+                          <td>
+                            <input
+                              type="text"
+                              value={profileEdits[p.id]?.pin ?? p.pin ?? ''}
+                              onChange={e =>
+                                handleProfileChange(p.id, 'pin', e.target.value)
+                              }
+                              onBlur={() => saveProfile(p.id)}
+                              className="input input-inline"
+                            />
+                          </td>
+                          <td>{p.customerPhone || '-'}</td>
+                          <td>
+                            {p.purchaseDate
+                              ? new Date(p.purchaseDate).toLocaleDateString()
+                              : '-'}
+                          </td>
+                          <td>
+                            {p.expirationDate
+                              ? new Date(p.expirationDate).toLocaleDateString()
+                              : '-'}
+                          </td>
+                          <td className="modal-profile-actions">
+                            <button
+                              type="button"
+                              onClick={() => handleProfileDelete(p.id)}
+                              className="btn btn-danger btn-sm"
+                            >
+                              Xóa
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleProfileTransfer(p.id)}
+                              className="btn btn-secondary btn-sm"
+                            >
+                              Chuyển
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <div className="modal-footer">
+                <button
+                  type="button"
+                  onClick={() => setSelected(null)}
+                  className="btn btn-ghost"
+                >
+                  Đóng
+                </button>
+              </div>
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary
- restyle the premium account management modal so profile tables fit within a wider layout and include usage context
- add compact form controls and button styles tailored for profile editing actions

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68db8007988083249f2c923c43cada75