### PR TITLE
Enhance admin dashboard layout and insights

### DIFF
--- a/frontend/src/admin/Admin.css
+++ b/frontend/src/admin/Admin.css
@@ -517,7 +517,8 @@
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 0.75rem;
+  gap: 0.85rem;
+  text-align: right;
 }
 
 .dashboard-hero-actions .btn-outline {
@@ -532,6 +533,17 @@
 
 .dashboard-hero-actions .btn-primary {
   min-width: 180px;
+}
+
+.hero-actions-group {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.hero-updated {
+  margin: 0;
+  font-size: 0.82rem;
+  color: rgba(15, 23, 42, 0.6);
 }
 
 .alert {
@@ -605,6 +617,38 @@
   fill: var(--primary);
 }
 
+.stat-card--customers .stat-icon {
+  background: rgba(37, 99, 235, 0.14);
+}
+
+.stat-card--customers .stat-icon svg {
+  fill: #2563eb;
+}
+
+.stat-card--active .stat-icon {
+  background: rgba(22, 163, 74, 0.16);
+}
+
+.stat-card--active .stat-icon svg {
+  fill: #16a34a;
+}
+
+.stat-card--balance .stat-icon {
+  background: rgba(229, 9, 20, 0.14);
+}
+
+.stat-card--balance .stat-icon svg {
+  fill: var(--primary);
+}
+
+.stat-card--growth .stat-icon {
+  background: rgba(124, 58, 237, 0.16);
+}
+
+.stat-card--growth .stat-icon svg {
+  fill: #7c3aed;
+}
+
 .stat-label {
   margin: 0;
   font-size: 0.85rem;
@@ -625,6 +669,11 @@
   font-size: 0.9rem;
 }
 
+.balance-badge.danger {
+  background: rgba(239, 68, 68, 0.14);
+  color: var(--danger);
+}
+
 /* ============================
    Data Surfaces & Tables
    ============================ */
@@ -637,6 +686,253 @@
   padding: 2rem;
   border: 1px solid rgba(15, 23, 42, 0.05);
   box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+}
+
+.surface-dashboard {
+  padding: 2.25rem;
+}
+
+.surface-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 2rem;
+  align-items: flex-start;
+}
+
+.data-region {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.data-region .form-search {
+  margin-bottom: 0;
+}
+
+.data-region .pagination {
+  margin-top: 0.5rem;
+}
+
+.insight-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.insight-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  padding: 1.75rem;
+  border-radius: 1rem;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.02), rgba(15, 23, 42, 0));
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.06);
+}
+
+.insight-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.insight-card-highlight {
+  background: linear-gradient(135deg, rgba(229, 9, 20, 0.16), rgba(229, 9, 20, 0.04));
+  border-color: rgba(229, 9, 20, 0.24);
+  color: var(--text-color);
+}
+
+.insight-number {
+  margin: 0;
+  font-size: 1.85rem;
+  font-weight: 700;
+}
+
+.insight-helper {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.7);
+}
+
+.insight-secondary {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.7);
+  font-size: 0.95rem;
+}
+
+.insight-secondary strong {
+  color: var(--primary);
+}
+
+.insight-divider {
+  width: 100%;
+  height: 1px;
+  background: rgba(15, 23, 42, 0.08);
+  margin: 0.4rem 0 0.2rem;
+}
+
+.insight-progress-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.95rem;
+  margin: 0;
+  padding: 0;
+}
+
+.insight-progress-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.insight-progress-header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.insight-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.12);
+}
+
+.insight-dot.success {
+  background: rgba(22, 163, 74, 0.65);
+}
+
+.insight-dot.warning {
+  background: rgba(245, 158, 11, 0.65);
+}
+
+.insight-dot.neutral {
+  background: rgba(15, 23, 42, 0.18);
+}
+
+.insight-dot.danger {
+  background: rgba(239, 68, 68, 0.65);
+}
+
+.insight-progress-label {
+  font-weight: 600;
+}
+
+.insight-progress-value {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.insight-progress-bar {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.06);
+  overflow: hidden;
+}
+
+.insight-progress-track {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--primary);
+}
+
+.insight-progress-track.success {
+  background: rgba(22, 163, 74, 0.85);
+}
+
+.insight-progress-track.warning {
+  background: rgba(245, 158, 11, 0.85);
+}
+
+.insight-progress-track.neutral {
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.insight-progress-track.danger {
+  background: rgba(239, 68, 68, 0.85);
+}
+
+.insight-progress-meta {
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.insight-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.insight-list-item {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.insight-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: rgba(229, 9, 20, 0.12);
+  display: grid;
+  place-items: center;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.insight-bullet {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: rgba(229, 9, 20, 0.45);
+  box-shadow: 0 0 0 4px rgba(229, 9, 20, 0.12);
+}
+
+.insight-list-content {
+  flex: 1;
+}
+
+.insight-list-title {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.insight-list-subtitle {
+  margin: 0.15rem 0 0;
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.insight-list-value {
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+.insight-empty {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 /* Ensure admin content cards stretch the full available width, overriding the
@@ -1247,6 +1543,15 @@
   .orders-controls {
     grid-template-columns: 1fr 1fr;
   }
+
+  .surface-body {
+    grid-template-columns: 1fr;
+  }
+
+  .insight-sidebar {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
 }
 
 @media (max-width: 768px) {
@@ -1276,6 +1581,15 @@
     width: 100%;
   }
 
+  .hero-actions-group {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .hero-updated {
+    text-align: left;
+  }
+
   .hero-meta {
     gap: 0.5rem;
   }
@@ -1301,6 +1615,14 @@
   .orders-quick-stats {
     grid-template-columns: repeat(2, minmax(140px, 1fr));
     gap: 0.75rem;
+  }
+
+  .surface-body {
+    gap: 1.5rem;
+  }
+
+  .insight-sidebar {
+    grid-template-columns: 1fr;
   }
 
 }
@@ -1330,6 +1652,14 @@
     padding: 0.75rem;
     background: rgba(248, 250, 252, 0.88);
     border-radius: 0.85rem;
+  }
+
+  .surface-dashboard {
+    padding: 1.6rem;
+  }
+
+  .insight-card {
+    padding: 1.25rem;
   }
 
 }

--- a/frontend/src/admin/AdminDashboard.jsx
+++ b/frontend/src/admin/AdminDashboard.jsx
@@ -83,6 +83,7 @@ export default function AdminDashboard() {
   const [showDelete, setShowDelete] = useState(false);
   const [selected, setSelected] = useState(null);
   const [amount, setAmount] = useState('');
+  const [lastUpdated, setLastUpdated] = useState(null);
   const token = localStorage.getItem('adminToken');
   const navigate = useNavigate();
 
@@ -100,6 +101,7 @@ export default function AdminDashboard() {
       });
       setCustomers(data.data);
       setPages(data.pages);
+      setLastUpdated(new Date());
       // Clear any previous message on successful refresh
       setMsg({ text: '', type: '' });
     } catch (err) {
@@ -189,6 +191,105 @@ export default function AdminDashboard() {
     [dashboardMetrics]
   );
 
+  const formattedLastUpdated = useMemo(() => {
+    if (!lastUpdated) return '';
+    try {
+      return new Intl.DateTimeFormat('vi-VN', {
+        hour: '2-digit',
+        minute: '2-digit',
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric',
+      }).format(lastUpdated);
+    } catch {
+      return '';
+    }
+  }, [lastUpdated]);
+
+  const balanceSegments = useMemo(() => {
+    if (!customers.length) {
+      return [
+        { key: 'high', label: '≥ 300K', count: 0, percent: 0, tone: 'success' },
+        { key: 'medium', label: '100K - 300K', count: 0, percent: 0, tone: 'warning' },
+        { key: 'low', label: '0 - 100K', count: 0, percent: 0, tone: 'neutral' },
+        { key: 'debt', label: 'Âm số dư', count: 0, percent: 0, tone: 'danger' },
+      ];
+    }
+
+    const distribution = {
+      high: 0,
+      medium: 0,
+      low: 0,
+      debt: 0,
+    };
+
+    customers.forEach((customer) => {
+      const amountValue = Number(customer.amount) || 0;
+      if (amountValue >= 300000) distribution.high += 1;
+      else if (amountValue >= 100000) distribution.medium += 1;
+      else if (amountValue > 0) distribution.low += 1;
+      else distribution.debt += 1;
+    });
+
+    const total = customers.length || 1;
+
+    return [
+      {
+        key: 'high',
+        label: '≥ 300K',
+        count: distribution.high,
+        percent: Math.round((distribution.high / total) * 100) || 0,
+        tone: 'success',
+      },
+      {
+        key: 'medium',
+        label: '100K - 300K',
+        count: distribution.medium,
+        percent: Math.round((distribution.medium / total) * 100) || 0,
+        tone: 'warning',
+      },
+      {
+        key: 'low',
+        label: '0 - 100K',
+        count: distribution.low,
+        percent: Math.round((distribution.low / total) * 100) || 0,
+        tone: 'neutral',
+      },
+      {
+        key: 'debt',
+        label: 'Âm số dư',
+        count: distribution.debt,
+        percent: Math.round((distribution.debt / total) * 100) || 0,
+        tone: 'danger',
+      },
+    ];
+  }, [customers]);
+
+  const topBalances = useMemo(() => {
+    if (!customers.length) return [];
+
+    return [...customers]
+      .filter((customer) => Number(customer.amount) > 0)
+      .sort((a, b) => (Number(b.amount) || 0) - (Number(a.amount) || 0))
+      .slice(0, 3);
+  }, [customers]);
+
+  const recentCustomers = useMemo(() => {
+    if (!customers.length) return [];
+
+    return [...customers]
+      .filter((customer) => customer.createdAt)
+      .sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      )
+      .slice(0, 5);
+  }, [customers]);
+
+  const averageBalance = useMemo(() => {
+    if (!dashboardMetrics.total) return 0;
+    return dashboardMetrics.balance / dashboardMetrics.total;
+  }, [dashboardMetrics]);
+
   // ========================
   // 3. Handlers
   // ========================
@@ -264,10 +365,10 @@ export default function AdminDashboard() {
     <AdminLayout>
       <section className="dashboard">
         <div className="dashboard-hero">
-          <div className="dashboard-hero-body">
-            <span className="hero-kicker">Tổng quan khách hàng</span>
-            <h1>Quản lý khách hàng</h1>
-            <p>Theo dõi tình trạng tài khoản và số dư khách hàng theo thời gian thực.</p>
+        <div className="dashboard-hero-body">
+          <span className="hero-kicker">Tổng quan khách hàng</span>
+          <h1>Quản lý khách hàng</h1>
+          <p>Theo dõi tình trạng tài khoản và số dư khách hàng theo thời gian thực.</p>
             <div className="hero-meta">
               <span className="hero-pill">
                 <strong>{formatNumber(dashboardMetrics.total)}</strong> khách hàng
@@ -281,12 +382,17 @@ export default function AdminDashboard() {
             </div>
           </div>
           <div className="dashboard-hero-actions">
-            <button onClick={fetchCustomers} className="btn btn-primary" type="button">
-              Làm mới dữ liệu
-            </button>
-            <Link to="/admin/orders" className="btn btn-outline">
-              Xem đơn hàng
-            </Link>
+            {formattedLastUpdated && (
+              <p className="hero-updated">Cập nhật: {formattedLastUpdated}</p>
+            )}
+            <div className="hero-actions-group">
+              <button onClick={fetchCustomers} className="btn btn-primary" type="button">
+                Làm mới dữ liệu
+              </button>
+              <Link to="/admin/orders" className="btn btn-outline">
+                Xem đơn hàng
+              </Link>
+            </div>
           </div>
         </div>
 
@@ -298,7 +404,7 @@ export default function AdminDashboard() {
 
         <div className="stat-card-grid">
           {statCards.map((card) => (
-            <article key={card.key} className="stat-card">
+            <article key={card.key} className={`stat-card stat-card--${card.key}`}>
               <div className="stat-icon">{statIcon(card.key)}</div>
               <div className="stat-content">
                 <p className="stat-label">{card.label}</p>
@@ -309,7 +415,7 @@ export default function AdminDashboard() {
           ))}
         </div>
 
-        <section className="surface-card">
+        <section className="surface-card surface-dashboard">
           <header className="surface-header">
             <div>
               <h2>Danh sách khách hàng</h2>
@@ -318,134 +424,224 @@ export default function AdminDashboard() {
             <div className="surface-meta">
               <span className="meta-item">Tổng số: {formatNumber(dashboardMetrics.total)}</span>
               <span className="meta-item">Đang hoạt động: {formatNumber(dashboardMetrics.active)}</span>
+              {formattedLastUpdated && (
+                <span className="meta-item">Lần cuối: {formattedLastUpdated}</span>
+              )}
             </div>
           </header>
 
-          <form onSubmit={handleSearch} className="form-search">
-            <div className="input-group">
-              <span className="input-icon" aria-hidden="true">🔍</span>
-              <input
-                type="text"
-                placeholder="Tìm kiếm theo số điện thoại"
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="input"
-              />
-            </div>
-            <button type="submit" className="btn btn-soft">
-              Tìm kiếm
-            </button>
-          </form>
+          <div className="surface-body">
+            <div className="data-region">
+              <form onSubmit={handleSearch} className="form-search">
+                <div className="input-group">
+                  <span className="input-icon" aria-hidden="true">🔍</span>
+                  <input
+                    type="text"
+                    placeholder="Tìm kiếm theo số điện thoại"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    className="input"
+                  />
+                </div>
+                <button type="submit" className="btn btn-soft">
+                  Tìm kiếm
+                </button>
+              </form>
 
-          <div className="table-container">
-            <table className="data-table">
-              <thead>
-                <tr>
-                  <th>STT</th>
-                  <th>Khách hàng</th>
-                  <th>Số điện thoại</th>
-                  <th>Ngày tạo</th>
-                  <th>Số dư</th>
-                  <th>Thao tác</th>
-                </tr>
-              </thead>
-              <tbody>
-                {customers.map((customer, idx) => {
-                  const safeId = customer._id || `${customer.phone}-${idx}`;
-                  const shortId = customer._id ? customer._id.slice(-6) : 'N/A';
-                  const avatarText = (customer.name || customer.phone || 'U')[0]?.toUpperCase();
-
-                  return (
-                    <tr key={safeId}>
-                      <td>{(page - 1) * 10 + idx + 1}</td>
-                      <td>
-                        <div className="customer-cell">
-                          <span className="customer-avatar">{avatarText}</span>
-                          <div>
-                            <p className="customer-name">{customer.name || 'Chưa cập nhật'}</p>
-                            <p className="customer-note">ID: {shortId}</p>
-                          </div>
-                        </div>
-                      </td>
-                      <td>
-                        <Link
-                          to={`/admin/customers/${customer._id}/orders`}
-                          className="link"
-                        >
-                          {customer.phone}
-                        </Link>
-                      </td>
-                      <td>{formatDate(customer.createdAt)}</td>
-                      <td>
-                        <span
-                          className={`balance-badge ${getBalanceTone(Number(customer.amount) || 0)}`}
-                        >
-                          {formatCurrency(customer.amount)}
-                        </span>
-                      </td>
-                      <td>
-                        <div className="table-actions">
-                          <a
-                            href={`/admin/customers/${customer._id}/reset-pin`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="btn btn-ghost"
-                          >
-                            Đặt lại PIN
-                          </a>
-                          <button
-                            onClick={() => openTopup(customer)}
-                            className="btn btn-soft"
-                            type="button"
-                          >
-                            Nạp tiền
-                          </button>
-                          <button
-                            onClick={() => openDelete(customer)}
-                            className="btn btn-danger"
-                            type="button"
-                          >
-                            Xóa
-                          </button>
-                        </div>
-                      </td>
+              <div className="table-container">
+                <table className="data-table">
+                  <thead>
+                    <tr>
+                      <th>STT</th>
+                      <th>Khách hàng</th>
+                      <th>Số điện thoại</th>
+                      <th>Ngày tạo</th>
+                      <th>Số dư</th>
+                      <th>Thao tác</th>
                     </tr>
-                  );
-                })}
-                {customers.length === 0 && (
-                  <tr>
-                    <td colSpan="6">
-                      <div className="empty-state">
-                        <h3>Không có dữ liệu</h3>
-                        <p>Hãy thử điều chỉnh bộ lọc hoặc thêm khách hàng mới.</p>
-                      </div>
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
+                  </thead>
+                  <tbody>
+                    {customers.map((customer, idx) => {
+                      const safeId = customer._id || `${customer.phone}-${idx}`;
+                      const shortId = customer._id ? customer._id.slice(-6) : 'N/A';
+                      const avatarText = (customer.name || customer.phone || 'U')[0]?.toUpperCase();
 
-          <div className="pagination">
-            <button
-              className="btn btn-ghost"
-              onClick={() => setPage((p) => Math.max(1, p - 1))}
-              disabled={page === 1}
-              type="button"
-            >
-              Trang trước
-            </button>
-            <span className="pagination-status">
-              Trang {page} / {pages}
-            </span>
-            <button
-              className="btn btn-ghost"
-              onClick={() => setPage((p) => Math.min(pages, p + 1))}
-              disabled={page === pages}
-              type="button"
-            >
-              Trang sau
-            </button>
+                      return (
+                        <tr key={safeId}>
+                          <td>{(page - 1) * 10 + idx + 1}</td>
+                          <td>
+                            <div className="customer-cell">
+                              <span className="customer-avatar">{avatarText}</span>
+                              <div>
+                                <p className="customer-name">{customer.name || 'Chưa cập nhật'}</p>
+                                <p className="customer-note">ID: {shortId}</p>
+                              </div>
+                            </div>
+                          </td>
+                          <td>
+                            <Link
+                              to={`/admin/customers/${customer._id}/orders`}
+                              className="link"
+                            >
+                              {customer.phone}
+                            </Link>
+                          </td>
+                          <td>{formatDate(customer.createdAt)}</td>
+                          <td>
+                            <span
+                              className={`balance-badge ${getBalanceTone(Number(customer.amount) || 0)}`}
+                            >
+                              {formatCurrency(customer.amount)}
+                            </span>
+                          </td>
+                          <td>
+                            <div className="table-actions">
+                              <a
+                                href={`/admin/customers/${customer._id}/reset-pin`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="btn btn-ghost"
+                              >
+                                Đặt lại PIN
+                              </a>
+                              <button
+                                onClick={() => openTopup(customer)}
+                                className="btn btn-soft"
+                                type="button"
+                              >
+                                Nạp tiền
+                              </button>
+                              <button
+                                onClick={() => openDelete(customer)}
+                                className="btn btn-danger"
+                                type="button"
+                              >
+                                Xóa
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                    {customers.length === 0 && (
+                      <tr>
+                        <td colSpan="6">
+                          <div className="empty-state">
+                            <h3>Không có dữ liệu</h3>
+                            <p>Hãy thử điều chỉnh bộ lọc hoặc thêm khách hàng mới.</p>
+                          </div>
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+
+              <div className="pagination">
+                <button
+                  className="btn btn-ghost"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page === 1}
+                  type="button"
+                >
+                  Trang trước
+                </button>
+                <span className="pagination-status">
+                  Trang {page} / {pages}
+                </span>
+                <button
+                  className="btn btn-ghost"
+                  onClick={() => setPage((p) => Math.min(pages, p + 1))}
+                  disabled={page === pages}
+                  type="button"
+                >
+                  Trang sau
+                </button>
+              </div>
+            </div>
+
+            <aside className="insight-sidebar" aria-label="Thông tin bổ sung">
+              <article className="insight-card insight-card-highlight">
+                <h3>Tình trạng số dư</h3>
+                <p className="insight-number">{formatCurrency(dashboardMetrics.balance)}</p>
+                <p className="insight-helper">Tổng số dư đang quản lý</p>
+                <div className="insight-divider" aria-hidden="true" />
+                <p className="insight-secondary">
+                  Trung bình <strong>{formatCurrency(averageBalance)}</strong> / khách
+                </p>
+              </article>
+
+              <article className="insight-card">
+                <h3>Phân bố số dư</h3>
+                <ul className="insight-progress-list">
+                  {balanceSegments.map((segment) => (
+                    <li key={segment.key} className="insight-progress-item">
+                      <div className="insight-progress-header">
+                        <span className={`insight-dot ${segment.tone}`} aria-hidden="true" />
+                        <span className="insight-progress-label">{segment.label}</span>
+                        <span className="insight-progress-value">
+                          {formatNumber(segment.count)} khách
+                        </span>
+                      </div>
+                      <div className="insight-progress-bar" role="presentation">
+                        <span
+                          className={`insight-progress-track ${segment.tone}`}
+                          style={{ width: `${segment.percent}%` }}
+                          aria-hidden="true"
+                        />
+                        <span className="sr-only">{segment.percent}% tổng khách</span>
+                      </div>
+                      <div className="insight-progress-meta">{segment.percent}% tổng khách</div>
+                    </li>
+                  ))}
+                </ul>
+              </article>
+
+              <article className="insight-card">
+                <h3>Khách số dư cao</h3>
+                <ul className="insight-list">
+                  {topBalances.length === 0 && <li className="insight-empty">Chưa có dữ liệu</li>}
+                  {topBalances.map((customer, idx) => (
+                    <li
+                      key={customer._id || `${customer.phone}-top-${idx}`}
+                      className="insight-list-item"
+                    >
+                      <div className="insight-avatar" aria-hidden="true">
+                        {(customer.name || customer.phone || 'U')[0]?.toUpperCase()}
+                      </div>
+                      <div className="insight-list-content">
+                        <p className="insight-list-title">{customer.name || 'Chưa cập nhật'}</p>
+                        <p className="insight-list-subtitle">{customer.phone}</p>
+                      </div>
+                      <span className="insight-list-value">{formatCurrency(customer.amount)}</span>
+                    </li>
+                  ))}
+                </ul>
+              </article>
+
+              <article className="insight-card">
+                <h3>Khách hàng mới</h3>
+                <ul className="insight-list">
+                  {recentCustomers.length === 0 && (
+                    <li className="insight-empty">Chưa có dữ liệu</li>
+                  )}
+                  {recentCustomers.map((customer, idx) => (
+                    <li
+                      key={customer._id || `${customer.phone}-recent-${idx}`}
+                      className="insight-list-item"
+                    >
+                      <div className="insight-bullet" aria-hidden="true" />
+                      <div className="insight-list-content">
+                        <p className="insight-list-title">{customer.name || customer.phone}</p>
+                        <p className="insight-list-subtitle">
+                          Ngày tạo: {formatDate(customer.createdAt)}
+                        </p>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </article>
+            </aside>
           </div>
         </section>
       </section>


### PR DESCRIPTION
## Summary
- restructure the admin dashboard hero and data sections with last-updated metadata and action grouping
- introduce an insight sidebar showing balance distribution, top customers, and recent signups alongside the customer table
- refresh admin styles for stat cards, insight widgets, and responsive behavior to present a cleaner UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcdd6ba9808324891edbc1fdd13e3a