### PR TITLE
Fix admin dashboard routing

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,6 @@
 // src/App.jsx
 import React, { useEffect } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 
 import Header            from './Header';
 import PlansOverview     from './PlansOverview';
@@ -110,18 +110,19 @@ export default function App() {
           path="/admin/dashboard"
           element={
             <AdminRoute>
-              <AdminStats />
-            </AdminRoute>
-          }
-        />
-        <Route
-          path="/admin"
-          element={
-            <AdminRoute>
               <AdminDashboard />
             </AdminRoute>
           }
         />
+        <Route
+          path="/admin/analytics"
+          element={
+            <AdminRoute>
+              <AdminStats />
+            </AdminRoute>
+          }
+        />
+        <Route path="/admin" element={<Navigate to="/admin/dashboard" replace />} />
         <Route
           path="/admin/netflix-accounts"
           element={

--- a/frontend/src/admin/AdminLayout.jsx
+++ b/frontend/src/admin/AdminLayout.jsx
@@ -8,7 +8,7 @@ export default function AdminLayout({ children }) {
 
   const links = [
     { href: '/admin/dashboard', label: 'Dashboard' },
-    { href: '/admin', label: 'Khách hàng' },
+    { href: '/admin/analytics', label: 'Thống kê' },
     { href: '/admin/orders', label: 'Đơn hàng' },
     { href: '/admin/netflix-accounts', label: 'Tài khoản gói cao cấp' },
     { href: '/admin/netflix-accounts-50k', label: 'Tài khoản gói tiết kiệm' },


### PR DESCRIPTION
## Summary
- ensure the admin dashboard route renders the dashboard view and redirect legacy /admin to it
- add a dedicated analytics route and navigation link for the statistics page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dce75ce9a48324970fcc939ad26070