### PR TITLE
Fix admin analytics EventSource URL

### DIFF
--- a/frontend/src/admin/AdminStats.jsx
+++ b/frontend/src/admin/AdminStats.jsx
@@ -163,9 +163,8 @@ export default function AdminStats() {
     fetchStats();
     fetchOrders();
 
-    const es = new EventSource(
-      `http://localhost:5000/api/admin/orders/stream?token=${encodeURIComponent(token)}`
-    );
+    const streamUrl = `/api/admin/orders/stream?token=${encodeURIComponent(token)}`;
+    const es = new EventSource(streamUrl);
 
     es.onmessage = (event) => {
       if (!isMountedRef.current) return;


### PR DESCRIPTION
## Summary
- use a relative URL for the admin analytics order stream so it works outside local environments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcfe868754832491f7bed47306176a