### PR TITLE
Highlight unhealthy premium accounts and recycle expired profiles

### DIFF
--- a/backend/controllers/adminController.js
+++ b/backend/controllers/adminController.js
@@ -259,8 +259,23 @@ export async function getNetflixAccounts(req, res) {
 
 export async function createNetflixAccount(req, res) {
   try {
-    const { email, password, note, plan } = req.body;
-    const acc = await NetflixAccount.create({ email, password, note, plan });
+    const { email, password, note, plan, healthStatus, healthNote } = req.body;
+    const payload = { email, password, note, plan };
+
+    if (typeof healthStatus === 'string' && healthStatus.trim()) {
+      payload.healthStatus = healthStatus.trim();
+    }
+
+    if (healthNote !== undefined) {
+      if (typeof healthNote === 'string') {
+        const trimmed = healthNote.trim();
+        payload.healthNote = trimmed || undefined;
+      } else {
+        payload.healthNote = healthNote;
+      }
+    }
+
+    const acc = await NetflixAccount.create(payload);
     res.json(acc);
   } catch (err) {
     console.error(err);
@@ -270,7 +285,7 @@ export async function createNetflixAccount(req, res) {
 
 export async function updateNetflixAccount(req, res) {
   try {
-    const { email, password, note, plan } = req.body;
+    const { email, password, note, plan, healthStatus, healthNote } = req.body;
     const acc = await NetflixAccount.findById(req.params.id);
     if (!acc) return res.status(404).json({ message: 'Không tìm thấy tài khoản' });
 
@@ -279,6 +294,21 @@ export async function updateNetflixAccount(req, res) {
     if (password !== undefined) acc.password = password;
     if (note !== undefined)     acc.note = note;
     if (plan !== undefined)     acc.plan = plan;
+    if (healthStatus !== undefined) {
+      if (typeof healthStatus === 'string' && healthStatus.trim()) {
+        acc.healthStatus = healthStatus.trim();
+      } else {
+        acc.healthStatus = 'healthy';
+      }
+    }
+    if (healthNote !== undefined) {
+      if (typeof healthNote === 'string') {
+        const trimmedNote = healthNote.trim();
+        acc.healthNote = trimmedNote || undefined;
+      } else {
+        acc.healthNote = healthNote;
+      }
+    }
     await acc.save();
 
     await Order.updateMany(
@@ -328,7 +358,36 @@ export async function assignProfile(req, res) {
     }
 
     // (3) Tìm hồ sơ trống
-    const profile = acc.profiles.find(p => p.status === 'empty');
+    let profile = acc.profiles.find(p => p.status === 'empty');
+    if (!profile) {
+      const now = Date.now();
+      const expiredProfileIds = [];
+
+      acc.profiles.forEach(p => {
+        if (p.status !== 'used' || !p.expirationDate) return;
+        const expiryTime = new Date(p.expirationDate).getTime();
+        if (Number.isNaN(expiryTime) || expiryTime >= now) return;
+
+        expiredProfileIds.push(p.id);
+        p.status = 'empty';
+        p.name = '';
+        p.pin = '';
+        p.customerPhone = undefined;
+        p.purchaseDate = undefined;
+        p.expirationDate = undefined;
+      });
+
+      if (expiredProfileIds.length) {
+        await acc.save();
+        await Order.updateMany(
+          { accountEmail: acc.email, profileId: { $in: expiredProfileIds } },
+          { $set: { status: 'EXPIRED' } }
+        );
+      }
+
+      profile = acc.profiles.find(p => p.status === 'empty');
+    }
+
     if (!profile) {
       return res.status(400).json({ message: 'Tài khoản không còn hồ sơ trống' });
     }

--- a/backend/models/NetflixAccount.js
+++ b/backend/models/NetflixAccount.js
@@ -46,6 +46,14 @@ const netflixAccountSchema = new mongoose.Schema(
     note: {
       type: String
     },
+    healthStatus: {
+      type: String,
+      enum: ['healthy', 'login_failed', 'unknown'],
+      default: 'healthy'
+    },
+    healthNote: {
+      type: String
+    },
     plan: {
       type: String,
       enum: ['Gói tiết kiệm', 'Gói cao cấp'],

--- a/frontend/src/admin/Admin.css
+++ b/frontend/src/admin/Admin.css
@@ -1022,6 +1022,34 @@
   gap: 0.45rem;
 }
 
+.account-warning-icon {
+  border: none;
+  background: linear-gradient(180deg, #facc15 0%, #fbbf24 100%);
+  color: #78350f;
+  font-weight: 700;
+  font-size: 0.9rem;
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 2px 6px rgba(250, 204, 21, 0.45);
+}
+
+.account-warning-icon:hover,
+.account-warning-icon:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 10px rgba(250, 204, 21, 0.55);
+}
+
+.account-warning-icon:focus {
+  outline: 2px solid rgba(250, 204, 21, 0.7);
+  outline-offset: 2px;
+}
+
 .expiration-cell {
   justify-content: flex-start;
 }

--- a/frontend/src/admin/AdminNetflixAccounts.jsx
+++ b/frontend/src/admin/AdminNetflixAccounts.jsx
@@ -229,6 +229,18 @@ export default function AdminNetflixAccounts() {
                   return !Number.isNaN(expiry.getTime()) && expiry.getTime() < now;
                 });
 
+                const issueNote = (() => {
+                  if (acc.healthStatus === 'login_failed') {
+                    return acc.healthNote?.trim() || 'Không đăng nhập được';
+                  }
+
+                  if (acc.note && acc.note.toLowerCase().includes('không đăng nhập')) {
+                    return acc.note;
+                  }
+
+                  return null;
+                })();
+
                 return (
                   <tr
                     key={acc._id}
@@ -237,6 +249,25 @@ export default function AdminNetflixAccounts() {
                   >
                     <td className="account-email-cell">
                       {acc.email}
+                      {issueNote && (
+                        <button
+                          type="button"
+                          className="account-warning-icon"
+                          title={issueNote}
+                          onClick={e => {
+                            e.stopPropagation();
+                            if (typeof window !== 'undefined' && typeof window.alert === 'function') {
+                              window.alert(issueNote);
+                            } else {
+                              // eslint-disable-next-line no-console
+                              console.info(issueNote);
+                            }
+                          }}
+                          aria-label={issueNote}
+                        >
+                          !
+                        </button>
+                      )}
                       {hasExpiredProfiles && (
                         <span
                           className="expiration-warning-icon"


### PR DESCRIPTION
## Summary
- add health status metadata to Netflix accounts and allow persisting notes via the admin APIs
- automatically recycle expired profiles before assigning new premium customers
- surface premium account login issues in the admin table with a yellow warning indicator and tooltip

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68de3dfdc1588324b3c7530f6b43beb1